### PR TITLE
fix: throw error instead of fallback spec

### DIFF
--- a/ui/server/viztrtr-workspaces/proj_1759610693511_v26hqbo/product-spec.json
+++ b/ui/server/viztrtr-workspaces/proj_1759610693511_v26hqbo/product-spec.json
@@ -1,0 +1,576 @@
+{
+  "projectId": "proj_1759610693511_v26hqbo",
+  "version": 1,
+  "createdAt": "2025-10-04T20:47:31.680Z",
+  "lastUpdated": "2025-10-04T20:47:31.680Z",
+  "productVision": "A revolutionary music performance system that enables musicians to focus on their artistry by providing real-time audio-synced lyrics and chords with zero distractions during live performance.",
+  "targetUsers": [
+    "Live performers (vocalists, guitarists, bands) performing 3-4 gigs per week who need large, readable fonts from 6ft away",
+    "Rehearsal musicians learning new songs who need to edit chords and practice with isolated stems",
+    "Casual hobbyists practicing at home who need simple, intuitive interfaces"
+  ],
+  "components": {
+    "TeleprompterView": {
+      "purpose": "Fullscreen lyrics display with real-time syllable highlighting that follows the musician during performance",
+      "userStories": [
+        "As a live performer, I need to see lyrics highlighted in real-time so I never miss a word during my set",
+        "As a vocalist, I need chords displayed above lyrics so I can sing and play simultaneously without looking away",
+        "As a stage musician, I need the active line centered and auto-scrolled so I don't lose my place",
+        "As a performing artist, I need fonts large enough to read from 6 feet away so I can move freely on stage"
+      ],
+      "designPriorities": [
+        "Maximum legibility from distance",
+        "Zero-latency syllable sync",
+        "Minimal visual distractions",
+        "Smooth auto-scrolling"
+      ],
+      "focusAreas": [
+        "Font size control (50%-150% of 56px base)",
+        "Syllable highlighting with cyan glow effect",
+        "Active line centering at 50% viewport",
+        "Past lyrics fade to 30% opacity",
+        "Chord positioning above lyrics with 80% size ratio",
+        "High contrast color palette (16:1 contrast ratio for lyrics)"
+      ],
+      "avoidAreas": [
+        "Complex animations that distract from lyrics",
+        "Multiple simultaneous visual effects",
+        "Small control buttons during performance",
+        "Unnecessary chrome or decorative elements"
+      ],
+      "acceptanceCriteria": [
+        "Sustains 60fps rendering for 10-minute songs",
+        "Syllable highlight latency < 50ms",
+        "Active line auto-centers within 100ms",
+        "Font size adjustable from 40px to 96px",
+        "WCAG AAA contrast (16:1) for lyrics",
+        "Readable from 6 feet away at default size"
+      ],
+      "status": "complete"
+    },
+    "AudioPlayer": {
+      "purpose": "Full-featured audio playback controls with time sync, volume, and seek functionality",
+      "userStories": [
+        "As a musician, I need to play/pause audio quickly so I can control practice flow",
+        "As a rehearsing artist, I need to seek to specific song positions so I can practice difficult sections repeatedly",
+        "As a performer, I need volume control so I can balance backing tracks with my live sound",
+        "As a user, I need to see current playback time so I know where I am in the song"
+      ],
+      "designPriorities": [
+        "Instant responsiveness",
+        "Precise seek control",
+        "Clear visual feedback",
+        "Minimal space usage"
+      ],
+      "focusAreas": [
+        "Play/pause button with clear icon states (▶ ⏸)",
+        "Draggable progress bar with cyan fill indicator",
+        "Volume slider (0.0-1.0) with mute toggle",
+        "Time display in MM:SS format with monospace font",
+        "Touch target size minimum 44x44px for mobile-readiness",
+        "Real-time sync callback for syllable highlighting"
+      ],
+      "avoidAreas": [
+        "Overly complex playback controls",
+        "Small or hard-to-hit buttons",
+        "Confusing icon choices",
+        "Lag between control interaction and audio response"
+      ],
+      "acceptanceCriteria": [
+        "Play/pause responds within 50ms",
+        "Seek accuracy within 100ms of target time",
+        "Progress bar updates at 60fps during playback",
+        "Volume changes apply instantly without clicks/pops",
+        "Time display accuracy within 100ms",
+        "All controls keyboard accessible"
+      ],
+      "status": "complete"
+    },
+    "StemSelector": {
+      "purpose": "Toggle between isolated audio stems (vocals, drums, bass, other) for focused practice",
+      "userStories": [
+        "As a vocalist, I need to isolate vocals so I can practice harmonies without distraction",
+        "As a bass player, I need to mute the bass track so I can play along without doubling",
+        "As a drummer, I need to hear only drums so I can learn complex patterns",
+        "As a musician, I need to see which stems are available before selecting them"
+      ],
+      "designPriorities": [
+        "Clear availability indication",
+        "Instant stem switching",
+        "Loading state visibility",
+        "Active selection clarity"
+      ],
+      "focusAreas": [
+        "5 stem types: Full Mix, Vocals, Bass, Drums, Other",
+        "Selected state: cyan background, black text, scale 105%, play icon",
+        "Unselected state: gray-700 background, white text",
+        "Loading state: 50% opacity, spinning icon",
+        "Unavailable state: 60% opacity, grayed out",
+        "HEAD request availability check before enabling"
+      ],
+      "avoidAreas": [
+        "Allowing selection of unavailable stems",
+        "Unclear loading states causing confusion",
+        "Abrupt audio switches causing jarring transitions",
+        "Too many simultaneous stem options overwhelming UI"
+      ],
+      "acceptanceCriteria": [
+        "Stem switches complete within 500ms",
+        "Loading spinner appears if load takes > 300ms",
+        "Unavailable stems clearly disabled and non-clickable",
+        "Active stem visually distinct from inactive",
+        "Keyboard navigation between stem options",
+        "No audio glitches during stem switching"
+      ],
+      "status": "complete"
+    },
+    "FullChart": {
+      "purpose": "Document-style song editor for structure, lyrics, and chord modifications",
+      "userStories": [
+        "As a musician, I need to edit auto-generated chords so I can correct mistakes",
+        "As a song arranger, I need to reorder sections so I can customize song structure",
+        "As a performer, I need to add section labels so I can organize complex arrangements",
+        "As a user, I need inline editing so I can make quick changes without mode switching"
+      ],
+      "designPriorities": [
+        "Intuitive inline editing",
+        "Clear section hierarchy",
+        "Quick chord corrections",
+        "Non-destructive editing"
+      ],
+      "focusAreas": [
+        "Click-to-edit for title, artist, lyrics, chords",
+        "Section headers (Verse, Chorus, Bridge, etc.) with visual separation",
+        "Chord positioning above corresponding lyrics",
+        "Add Section button with clear affordance",
+        "Drag handles for section reordering (Sprint 4)",
+        "Chord autocomplete suggestions (Sprint 4)",
+        "Real-time validation for chord syntax"
+      ],
+      "avoidAreas": [
+        "Complex modal dialogs for simple edits",
+        "Losing focus during inline editing",
+        "Unclear edit boundaries",
+        "Accidental edits without confirmation"
+      ],
+      "acceptanceCriteria": [
+        "Click-to-edit activates within 100ms",
+        "Changes save automatically within 500ms",
+        "Section reordering via drag-and-drop (Sprint 4)",
+        "Chord autocomplete shows top 5 suggestions (Sprint 4)",
+        "Invalid chords highlighted with red underline",
+        "Undo/redo functionality for all edits"
+      ],
+      "status": "complete"
+    },
+    "LibraryView": {
+      "purpose": "Song search, filtering, and library management interface",
+      "userStories": [
+        "As a performer with 100+ songs, I need instant search so I can find songs quickly before a gig",
+        "As a musician, I need to filter by key so I can find songs matching my vocal range",
+        "As a user, I need to sort by last played so I can find recently practiced songs",
+        "As a performer, I need quick actions (play, edit, delete) so I can manage my setlist efficiently"
+      ],
+      "designPriorities": [
+        "Search speed (<5s)",
+        "Clear filtering options",
+        "Quick action accessibility",
+        "Visual song card design"
+      ],
+      "focusAreas": [
+        "Instant search with fuzzy matching across title, artist, lyrics, tags",
+        "Filter controls: genre, key, BPM range, difficulty level",
+        "Sort options: title (A-Z), date added, last played, BPM",
+        "Song cards with metadata (title, artist, key, BPM, duration)",
+        "Quick action buttons: Play, Edit, Delete with confirmation",
+        "Autocomplete suggestions (Sprint 4)",
+        "Empty state messaging when no results"
+      ],
+      "avoidAreas": [
+        "Slow search causing frustration",
+        "Too many filter options overwhelming users",
+        "Accidental deletions without confirmation",
+        "Poor performance with large libraries (1000+ songs)"
+      ],
+      "acceptanceCriteria": [
+        "Search results appear within 300ms of typing",
+        "Fuzzy matching handles 2-character typos",
+        "Filters apply instantly without page reload",
+        "Library supports 1000+ songs without lag",
+        "Delete action requires confirmation modal",
+        "Keyboard navigation through search results"
+      ],
+      "status": "complete"
+    },
+    "SettingsPanel": {
+      "purpose": "Quick access panel for performance controls and display preferences",
+      "userStories": [
+        "As a performer, I need to transpose songs quickly so I can match my vocal range",
+        "As a guitarist, I need to set capo position so chords display correctly for my setup",
+        "As a stage musician, I need to adjust font size mid-rehearsal so I can see from my position",
+        "As a user with visual impairments, I need high contrast mode so I can read comfortably"
+      ],
+      "designPriorities": [
+        "Fast setting changes (<2s)",
+        "Clear control labeling",
+        "Preset support",
+        "Non-modal access"
+      ],
+      "focusAreas": [
+        "Chord display mode toggle (Off, Names, Diagrams)",
+        "Font size slider with real-time preview (50%-150%)",
+        "Transpose control (-12 to +12 semitones) with key display",
+        "Capo control (0-12 frets) with chord recalculation",
+        "High contrast mode toggle (Sprint 3)",
+        "Settings presets (Sprint 4): Stage, Rehearsal, Practice",
+        "Slide-in panel from left (384px width)"
+      ],
+      "avoidAreas": [
+        "Settings requiring page reload",
+        "Unclear units or value ranges",
+        "Too many nested options",
+        "Modal dialogs that block content"
+      ],
+      "acceptanceCriteria": [
+        "Settings apply within 2 seconds",
+        "Font size changes visible immediately",
+        "Transpose updates all chords correctly",
+        "Panel slides in/out within 300ms",
+        "Settings persist across sessions",
+        "Keyboard shortcuts work (Cmd+,)"
+      ],
+      "status": "complete"
+    },
+    "Header": {
+      "purpose": "Top navigation bar with core actions and song context",
+      "userStories": [
+        "As a user, I need quick access to settings so I can adjust preferences without interrupting practice",
+        "As a musician, I need to upload new songs easily so I can expand my library",
+        "As a new user, I need a demo button so I can explore features immediately",
+        "As a performer, I need to see current song title so I know what I'm performing"
+      ],
+      "designPriorities": [
+        "Always accessible",
+        "Minimal height",
+        "Clear hierarchy",
+        "Fast actions"
+      ],
+      "focusAreas": [
+        "Settings button (gear icon) with cyan background on left",
+        "Upload Song button with clear upload affordance",
+        "Demo button for first-time users",
+        "Song title/artist display centered",
+        "Fixed position header (120-180px height)",
+        "Responsive layout for smaller screens",
+        "High contrast icons for visibility"
+      ],
+      "avoidAreas": [
+        "Excessive height stealing screen space",
+        "Too many action buttons causing clutter",
+        "Hidden or unclear navigation",
+        "Auto-hiding behavior during performance"
+      ],
+      "acceptanceCriteria": [
+        "Header height ≤ 180px",
+        "All buttons minimum 44x44px touch target",
+        "Settings panel opens within 300ms",
+        "Upload dialog appears within 200ms",
+        "Song title truncates gracefully on narrow screens",
+        "Header visible at all times (no auto-hide)"
+      ],
+      "status": "complete"
+    },
+    "ChordDiagram": {
+      "purpose": "Visual guitar chord fingering display for performance reference",
+      "userStories": [
+        "As a guitarist learning songs, I need visual chord diagrams so I can see proper fingering",
+        "As a beginner, I need clear fret markers so I know where to place my fingers",
+        "As a performer, I need compact diagrams so they don't obscure lyrics"
+      ],
+      "designPriorities": [
+        "Clear visual representation",
+        "Compact size",
+        "High contrast",
+        "Standard notation"
+      ],
+      "focusAreas": [
+        "Fretboard grid with 6 strings × 5 frets",
+        "Finger position dots with fret numbers",
+        "Open/muted string indicators at top (O/X)",
+        "Chord name label above diagram",
+        "SVG-based for crisp scaling",
+        "Dark theme compatible colors",
+        "Standard chord library (120+ common chords)"
+      ],
+      "avoidAreas": [
+        "Overly complex or decorative designs",
+        "Colors that blend with dark background",
+        "Non-standard chord notation",
+        "Diagrams too large for teleprompter view"
+      ],
+      "acceptanceCriteria": [
+        "Diagram renders within 50ms",
+        "All elements contrast ratio ≥ 4.5:1",
+        "Diagram scales correctly from 50%-150%",
+        "Supports 120+ standard chord shapes",
+        "Clear visual distinction between frets and strings",
+        "Accessible with screen readers (SVG title/desc)"
+      ],
+      "status": "complete"
+    },
+    "UploadFlow": {
+      "purpose": "Guided workflow for uploading and analyzing new songs",
+      "userStories": [
+        "As a musician, I need to drag-and-drop audio files so I can quickly add songs to my library",
+        "As a user, I need to see analysis progress so I know when my song is ready",
+        "As a performer, I need error feedback so I know if upload failed and why",
+        "As a user, I need automatic navigation to my new song so I can start practicing immediately"
+      ],
+      "designPriorities": [
+        "Simple upload UX",
+        "Clear progress indication",
+        "Fast analysis (<30s)",
+        "Error recovery"
+      ],
+      "focusAreas": [
+        "Drag-and-drop zone with clear visual feedback",
+        "Supported formats: WAV, MP3, M4A, FLAC",
+        "Progress bar with percentage and stage labels",
+        "Analysis stages: Upload → Extract → Analyze → Generate Map",
+        "Error messages with actionable recovery steps",
+        "Auto-redirect to TeleprompterView on completion",
+        "Cancel upload option during processing"
+      ],
+      "avoidAreas": [
+        "Blocking UI during upload",
+        "Unclear progress states",
+        "No error recovery options",
+        "Silent failures without user notification"
+      ],
+      "acceptanceCriteria": [
+        "Upload completes within 5s for 5MB file",
+        "Analysis completes within 30s per song",
+        "Progress updates every 500ms",
+        "Clear error messages for unsupported formats",
+        "Cancel stops processing immediately",
+        "Auto-save to library on completion"
+      ],
+      "status": "complete"
+    },
+    "KeyboardShortcuts": {
+      "purpose": "Comprehensive keyboard navigation system for hands-free control",
+      "userStories": [
+        "As a performer with hands on instrument, I need keyboard shortcuts so I can control playback without clicking",
+        "As a power user, I need quick navigation shortcuts so I can switch views rapidly",
+        "As a user practicing, I need section navigation shortcuts so I can jump to specific parts quickly",
+        "As an accessibility user, I need all features keyboard accessible so I can use the app without a mouse"
+      ],
+      "designPriorities": [
+        "Complete keyboard coverage",
+        "Muscle memory-friendly",
+        "Standard conventions",
+        "Discoverable shortcuts"
+      ],
+      "focusAreas": [
+        "Space: Play/pause in TeleprompterView",
+        "←/→: Previous/next section navigation",
+        "Cmd+,: Open settings panel",
+        "Cmd+L: Open library view",
+        "Cmd+E: Toggle edit mode",
+        "Esc: Close modals and panels",
+        "Tab: Navigate through controls",
+        "Cmd+↑/↓: Increase/decrease font size by 10%",
+        "Shortcut reference panel (? key to open)",
+        "Visual focus indicators on all interactive elements"
+      ],
+      "avoidAreas": [
+        "Conflicting with browser shortcuts",
+        "Non-standard key combinations",
+        "Hidden shortcuts without documentation",
+        "Shortcuts that don't work in all contexts"
+      ],
+      "acceptanceCriteria": [
+        "All 8 core shortcuts respond within 50ms",
+        "Tab navigation follows logical visual order",
+        "Focus indicators visible (2px cyan outline)",
+        "Shortcut reference accessible via ? key",
+        "No conflicts with Chrome/Safari/Firefox defaults",
+        "Works with screen readers (ARIA labels)"
+      ],
+      "status": "planned-sprint-3"
+    },
+    "PerformanceOptimization": {
+      "purpose": "Ensure smooth 60fps rendering and sub-100ms interaction latency",
+      "userStories": [
+        "As a performer, I need smooth scrolling so the lyrics don't judder during playback",
+        "As a user, I need instant settings changes so adjustments don't interrupt my flow",
+        "As a musician with long songs, I need consistent performance even for 10+ minute tracks"
+      ],
+      "designPriorities": ["60fps sustained", "Virtual scrolling", "Memoization", "Lazy loading"],
+      "focusAreas": [
+        "Virtual scrolling for TeleprompterView (render only visible lines)",
+        "React.memo for syllable components to prevent re-renders",
+        "RequestAnimationFrame for smooth highlight updates",
+        "Web Workers for background processing",
+        "Debounce settings changes (300ms)",
+        "Lazy load chord diagrams on demand",
+        "Optimize syllable sync algorithm for O(log n) lookup"
+      ],
+      "avoidAreas": [
+        "Rendering entire song map in DOM",
+        "Synchronous blocking operations",
+        "Excessive React re-renders",
+        "Unoptimized image/SVG rendering"
+      ],
+      "acceptanceCriteria": [
+        "Sustains 60fps for 10-minute songs",
+        "Settings changes apply within 2 seconds",
+        "Initial render completes within 1 second",
+        "Syllable highlight updates every 16.67ms (60fps)",
+        "Memory usage < 500MB for large libraries",
+        "No frame drops during auto-scroll"
+      ],
+      "status": "in-progress-sprint-3"
+    },
+    "AccessibilityLayer": {
+      "purpose": "Ensure WCAG 2.1 AA compliance with AAA for critical performance elements",
+      "userStories": [
+        "As a visually impaired user, I need high contrast modes so I can read lyrics clearly",
+        "As a screen reader user, I need proper ARIA labels so I can navigate the app independently",
+        "As a user with motor impairments, I need large touch targets so I can control playback easily",
+        "As a user sensitive to motion, I need to disable animations so the app is comfortable to use"
+      ],
+      "designPriorities": [
+        "WCAG 2.1 AA minimum",
+        "AAA for performance views",
+        "Semantic HTML",
+        "Keyboard first"
+      ],
+      "focusAreas": [
+        "Lyrics contrast ratio: 16:1 (WCAG AAA)",
+        "Chord contrast ratio: 7:1 (WCAG AAA)",
+        "UI controls contrast: 4.5:1 (WCAG AA)",
+        "ARIA labels on all interactive elements",
+        "ARIA live regions for dynamic content (syllable changes)",
+        "Semantic HTML (<main>, <nav>, <section>, <article>)",
+        "Focus indicators: 2px cyan outline, visible on all elements",
+        "High contrast mode toggle (black-on-white)",
+        "Reduced motion mode (prefers-reduced-motion)",
+        "Minimum touch targets: 44x44px"
+      ],
+      "avoidAreas": [
+        "Decorative div soup without semantic meaning",
+        "Missing alt text on icons",
+        "Keyboard traps in modals",
+        "Animations that cannot be disabled"
+      ],
+      "acceptanceCriteria": [
+        "Lighthouse accessibility score ≥ 95",
+        "All elements pass WCAG contrast checker",
+        "Screen reader announces all state changes",
+        "Keyboard navigation reaches all interactive elements",
+        "Focus never trapped in modal dialogs",
+        "All touch targets ≥ 44x44px",
+        "High contrast mode passes WCAG AAA",
+        "Animations respect prefers-reduced-motion"
+      ],
+      "status": "in-progress-sprint-3"
+    },
+    "SongMapDemo": {
+      "purpose": "Interactive demonstration of Song Map structure for first-time users",
+      "userStories": [
+        "As a first-time user, I need a demo song pre-loaded so I can explore features immediately",
+        "As a new musician, I need to see example song structure so I understand how to organize my songs",
+        "As a potential customer, I need a working demo so I can evaluate the product before uploading my own music"
+      ],
+      "designPriorities": [
+        "Instant availability",
+        "Representative example",
+        "Clear structure",
+        "Fast loading"
+      ],
+      "focusAreas": [
+        "Pre-loaded demo: 'Yesterday' by The Beatles",
+        "Complete Song Map with all sections (Verse, Chorus, Bridge)",
+        "Real audio file with all stems available",
+        "Accurate chord progressions and lyrics",
+        "Demonstrates all major features (syllable sync, stems, editing)",
+        "Loads automatically on first app open",
+        "Demo badge in UI to indicate example content"
+      ],
+      "avoidAreas": [
+        "Overly simplified demo that misrepresents real usage",
+        "Demo requiring network request to load",
+        "Copyright-protected music without proper licensing",
+        "Demo that's too long or complex for quick evaluation"
+      ],
+      "acceptanceCriteria": [
+        "Demo loads within 1 second",
+        "All features functional in demo mode",
+        "Demo clearly labeled as example content",
+        "Easy transition from demo to user's own songs",
+        "Demo song < 3 minutes for quick testing",
+        "All stems available for demo song"
+      ],
+      "status": "complete"
+    }
+  },
+  "globalConstraints": {
+    "accessibility": [
+      "WCAG 2.1 AA minimum compliance",
+      "WCAG 2.1 AAA for performance-critical elements (lyrics, chords)",
+      "Semantic HTML5 with proper landmark roles",
+      "ARIA labels on all interactive elements",
+      "ARIA live regions for dynamic content updates",
+      "Keyboard navigation for all functionality (8 core shortcuts)",
+      "Focus indicators visible on all interactive elements (2px cyan outline)",
+      "Screen reader support (VoiceOver, NVDA, JAWS)",
+      "High contrast mode option",
+      "Reduced motion support (respects prefers-reduced-motion)",
+      "Minimum touch target size: 44x44px",
+      "Text resize support up to 200% without loss of functionality"
+    ],
+    "performance": [
+      "60fps sustained rendering for 10-minute songs",
+      "< 100ms perceived interaction latency",
+      "< 50ms audio latency for syllable sync",
+      "< 2 seconds for settings changes to apply",
+      "< 5 seconds for song search results",
+      "< 30 seconds for complete song analysis",
+      "< 500MB memory usage for large libraries (1000+ songs)",
+      "Virtual scrolling for large song maps",
+      "RequestAnimationFrame for smooth animations",
+      "Debounced user inputs (300ms)",
+      "Lazy loading for non-critical assets",
+      "Web Workers for background processing"
+    ],
+    "browser": [
+      "Chrome 100+ (primary target)",
+      "Safari 15+ (macOS/iOS)",
+      "Firefox 100+",
+      "Edge 100+",
+      "Desktop-first (mobile support Phase 2)",
+      "Minimum resolution: 1280×720",
+      "Recommended resolution: 1920×1080 or higher",
+      "Web Audio API support required",
+      "ES6+ JavaScript support"
+    ],
+    "design": [
+      "Performance-first: UI disappears during performance",
+      "Zero-latency feel: < 100ms perceived interaction time",
+      "Musician mental model: Sections, keys, chords",
+      "Progressive disclosure: Complexity hidden until needed",
+      "Accessibility by default: Works for all musicians",
+      "Dark theme optimized for stage lighting (near-black bg: rgb(10,10,12))",
+      "Performia cyan (#06b6d4) as primary accent color",
+      "Typography scale: 40px-96px for performance, 12px-40px for UI",
+      "Spacing system: 4px, 8px, 16px, 24px, 32px, 48px",
+      "Border radius: 4px, 8px, 12px, 16px, full",
+      "Shadows for depth: sm, md, lg, xl, cyan glow",
+      "Tailwind CSS 4 utility classes",
+      "Mobile-first responsive grid (desktop priority for MVP)",
+      "Consistent 8px baseline grid"
+    ]
+  },
+  "originalPRD": "# 🎵 Performia - Complete Documentation\n\n**Version:** 3.0\n**Last Updated:** October 1, 2025\n**Status:** Living Document\n\n---\n\n## 📖 Table of Contents\n\n### Quick Navigation\n- [🎯 Product Overview](#-product-overview)\n- [🚀 Quick Start](#-quick-start)\n- [🏗️ Architecture](#️-architecture)\n- [🎨 Design System](#-design-system)\n- [🧩 Component Library](#-component-library)\n- [📋 Feature Status](#-feature-status)\n- [🗺️ Roadmap](#️-roadmap)\n- [🔧 Developer Guide](#-developer-guide)\n- [♿ Accessibility](#-accessibility)\n- [📊 Success Metrics](#-success-metrics)\n\n---\n\n## 🎯 Product Overview\n\n### What is Performia?\n\n**Performia** is a revolutionary music performance system that transforms how musicians perform live. By combining real-time audio analysis, AI-powered audio processing, and an intelligent \"Living Chart\" teleprompter, Performia enables musicians to focus on their artistry.\n\n**Core Value Proposition:**\n*\"Never forget lyrics or chords again. Performia follows YOU in real-time.\"*\n\n### Target Users\n\n1. **Live Performers** (Primary)\n   - Vocalists, guitarists, bands\n   - Perform 3-4 gigs per week\n   - Need large fonts readable from 6ft away\n   - Zero distractions during performance\n\n2. **Rehearsal Musicians** (Secondary)\n   - Learning new songs\n   - Need to edit chords and structure\n   - Practice with isolated stems\n\n3. **Casual Hobbyists** (Tertiary)\n   - Home practice\n   - Need simple, intuitive interface\n   - Explore demo songs\n\n### Design Philosophy\n\n> **\"The best interface for performance is no interface at all.\"**\n\n**Core Principles:**\n1. **Performance-First**: UI disappears during performance\n2. **Zero-Latency Feel**: <100ms perceived interaction time\n3. **Musician Mental Model**: Sections, keys, chords\n4. **Progressive Disclosure**: Complexity hidden until needed\n5. **Accessibility by Default**: Works for all musicians\n\n---\n\n## 🚀 Quick Start\n\n### Running Performia\n\n#### Backend (Python + C++)\n```bash\ncd backend\npython -m venv venv\nsource venv/bin/activate  # On Windows: venv\\Scripts\\activate\npip install -r requirements.txt\npython src/main.py\n```\n\nBackend runs on: `http://localhost:8000`\n\n#### Frontend (React + Vite)\n```bash\ncd frontend\nnpm install\nnpm run dev\n```\n\nFrontend runs on: `http://localhost:5001`\n\n### First-Time User Flow\n\n1. **Open Performia** → Demo song \"Yesterday\" loads automatically\n2. **Click Settings** (gear icon) → Adjust font size, transpose\n3. **Click Play** → Watch syllables highlight in real-time\n4. **Upload Song** → Drop audio file, wait ~30s for analysis\n5. **Perform** → Fullscreen lyrics with chords, zero distractions\n\n---\n\n## 🏗️ Architecture\n\n### Tech Stack\n\n**Frontend:**\n- React 19 + TypeScript 5\n- Vite 6 (build tool)\n- Tailwind CSS 4 (styling)\n- React hooks (state management)\n\n**Backend:**\n- Python 3.11 + FastAPI\n- JUCE (C++ audio engine)\n- Librosa (audio analysis)\n- Demucs (stem separation)\n- Whisper (speech recognition / ASR)\n- **SongPrep** (planned - song structure parsing)\n\n### Data Flow\n\n```\n1. Upload Audio → Backend\n2. Analysis Pipeline → Song Map JSON\n3. Frontend → Display Living Chart\n4. Audio Playback → Syllable Sync\n```\n\n### Song Map Schema\n\n```json\n{\n  \"title\": \"Song Title\",\n  \"artist\": \"Artist Name\",\n  \"key\": \"C Major\",\n  \"bpm\": 120,\n  \"sections\": [\n    {\n      \"name\": \"Verse 1\",\n      \"lines\": [\n        {\n          \"syllables\": [\n            {\n              \"text\": \"Hello\",\n              \"startTime\": 0.5,\n              \"duration\": 0.3,\n              \"chord\": \"C\"\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}\n```\n\n### API Endpoints\n\n| Endpoint | Method | Purpose |\n|----------|--------|---------|\n| `/upload` | POST | Upload audio file |\n| `/progress/:jobId` | GET | Analysis progress |\n| `/songmap/:jobId` | GET | Get Song Map JSON |\n| `/audio/:jobId/original` | GET | Get original audio |\n| `/audio/:jobId/stem/:type` | GET | Get stem (vocals, bass, drums, other) |\n\n---\n\n## 🎨 Design System\n\n### Color Palette\n\n#### Performance Mode (Stage)\n```css\n--bg-performance: rgb(10, 10, 12)      /* Near-black, minimal glare */\n--text-lyrics: rgb(240, 240, 245)      /* Cool white, max legibility */\n--chord-inactive: #FACC15              /* Warm amber (WCAG AAA) */\n--chord-active: #06b6d4                /* Performia cyan */\n--highlight-sung: rgba(6, 182, 212, 0.3)  /* Cyan glow */\n```\n\n#### UI Chrome (Controls)\n```css\n--bg-chrome: #111827                   /* Gray-900 */\n--bg-panel: #1f2937                    /* Gray-800 */\n--bg-input: #374151                    /* Gray-700 */\n--accent-primary: #06b6d4              /* Performia cyan */\n--accent-hover: #06d4f1                /* Lighter cyan */\n--accent-success: #22c55e              /* Green */\n--accent-warning: #eab308              /* Yellow */\n--accent-error: #ef4444                /* Red */\n```\n\n### Typography Scale\n\n```css\n/* Teleprompter (Performance) */\n--font-lyrics-default: 3.5rem   /* 56px - Stage optimized */\n--font-lyrics-min: 2.5rem       /* 40px */\n--font-lyrics-max: 6.0rem       /* 96px */\n--font-chord: 2.8rem            /* 45px - 80% ratio maintained */\n\n/* UI Chrome */\n--font-header-1: 2.5rem         /* Song title */\n--font-header-2: 1.875rem       /* Artist */\n--font-body: 1.125rem           /* Editable text */\n--font-control: 1rem            /* Buttons */\n--font-label: 0.875rem          /* Labels */\n--font-caption: 0.75rem         /* Metadata */\n```\n\n### Spacing System\n\n```css\n--space-xs:   4px\n--space-sm:   8px\n--space-md:   16px\n--space-lg:   24px\n--space-xl:   32px\n--space-2xl:  48px\n```\n\n### Border Radius\n\n```css\n--radius-sm:  4px\n--radius-md:  8px\n--radius-lg:  12px\n--radius-xl:  16px\n--radius-full: 9999px  /* Pill shape */\n```\n\n### Shadows\n\n```css\n--shadow-sm: 0 1px 2px rgba(0,0,0,0.05)\n--shadow-md: 0 4px 6px rgba(0,0,0,0.1)\n--shadow-lg: 0 10px 15px rgba(0,0,0,0.1)\n--shadow-xl: 0 20px 25px rgba(0,0,0,0.1)\n--shadow-cyan: 0 10px 15px rgba(6,182,212,0.2)\n```\n\n---\n\n## 🧩 Component Library\n\n### Core Components\n\n#### 1. TeleprompterView (Living Chart)\n**File:** `frontend/components/TeleprompterView.tsx`\n\n**Purpose:** Fullscreen lyrics with real-time syllable highlighting\n\n**Features:**\n- Real-time syllable highlighting\n- Auto-scroll (active line centered)\n- Chord display (names or diagrams)\n- Audio controls integration\n- Font size control (50%-150%)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│ [Audio Controls Bar]                │  ← 120-180px height\n├─────────────────────────────────────┤\n│                                     │\n│    Past lyrics (30% opacity)        │\n│                                     │\n│  ╔═══════════════════════════════╗ │\n│  ║   C              G            ║ │  ← Active line\n│  ║   Here comes the sun ◆ doo   ║ │  ← ◆ = current syllable\n│  ╚═══════════════════════════════╝ │\n│                                     │\n│    Future lyrics (100% opacity)     │\n│                                     │\n└─────────────────────────────────────┘\n```\n\n**Props:**\n```typescript\ninterface TeleprompterViewProps {\n  songMap: SongMap;\n  transpose: number;\n  capo: number;\n  chordDisplay: 'off' | 'names' | 'diagrams';\n  jobId?: string;\n}\n```\n\n---\n\n#### 2. AudioPlayer ✨ NEW\n**File:** `frontend/components/AudioPlayer.tsx`\n\n**Purpose:** Full-featured audio player with playback controls\n\n**Features:**\n- Play/pause button\n- Progress bar (draggable seek)\n- Volume control (slider + mute)\n- Time display (MM:SS / MM:SS)\n- Real-time sync with lyrics\n\n**UI Elements:**\n- **Progress Bar:** Cyan fill, gray background, draggable\n- **Play/Pause:** Cyan button, black text, icons ▶ ⏸\n- **Volume:** Slider (0.0-1.0), mute button 🔇 🔉 🔊\n- **Time:** Monospace font, white text\n\n**Container:** Gray-800 background, 16px padding, 8px radius\n\n**Props:**\n```typescript\ninterface AudioPlayerProps {\n  audioUrl: string;\n  onTimeUpdate: (currentTime: number) => void;\n  onDurationChange?: (duration: number) => void;\n  onPlayStateChange?: (isPlaying: boolean) => void;\n}\n```\n\n---\n\n#### 3. StemSelector ✨ NEW\n**File:** `frontend/components/StemSelector.tsx`\n\n**Purpose:** Toggle between audio stems (vocals, drums, bass, etc.)\n\n**Features:**\n- 5 stem types: Full Mix, Vocals, Bass, Drums, Other\n- Loading states (spinner icon)\n- Availability check (HEAD request)\n- Active state highlighting\n\n**Button States:**\n- **Selected:** Cyan background, black text, scale 105%, play icon ▶\n- **Unselected:** Gray-700 background, white text, hover gray-600\n- **Loading:** 50% opacity, spinning clock ⌛\n- **Unavailable:** 60% opacity, grayed out\n\n**Props:**\n```typescript\ninterface StemSelectorProps {\n  jobId: string;\n  baseUrl?: string;\n  onStemChange: (stemUrl: string, stemType: StemType) => void;\n}\n\ntype StemType = 'original' | 'vocals' | 'bass' | 'drums' | 'other';\n```\n\n---\n\n#### 4. Full Chart (Song Editor)\n**File:** `frontend/components/BlueprintView.tsx`\n\n**Purpose:** Document-style editor for song structure and chords\n\n**Features:**\n- Inline editing (click to edit)\n- Edit title, artist, lyrics, chords\n- Section headers (Verse, Chorus, etc.)\n- Chord autocomplete (planned Sprint 4)\n- Drag-to-reorder sections (planned Sprint 4)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│  Song Title (editable)              │\n│  Artist Name (editable)             │\n│  Key: C Major | BPM: 120            │\n├─────────────────────────────────────┤\n│  ┌─ [ Verse 1 ] ─────────────────┐ │\n│  │  C            G                │ │\n│  │  Here comes the sun           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  ┌─ [ Chorus ] ──────── [⋮] ─────┐ │  ← Drag handle\n│  │  ...                           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  [+ Add Section]                    │\n└─────────────────────────────────────┘\n```\n\n---\n\n#### 5. LibraryView\n**File:** `frontend/components/LibraryView.tsx`\n\n**Purpose:** Song search and library management\n\n**Features:**\n- Instant search (title, artist, lyrics, tags)\n- Filter by genre, key, BPM, difficulty\n- Sort by title, date added, last played\n- Quick actions: Play, Edit, Delete\n- Song cards with metadata\n\n**Search:** Fuzzy matching, autocomplete (planned Sprint 4)\n\n---\n\n#### 6. SettingsPanel\n**File:** `frontend/components/SettingsPanel.tsx`\n\n**Purpose:** Quick access to performance controls\n\n**Features:**\n- Chord display mode (Off, Names, Diagrams)\n- Font size slider (50%-150%)\n- Transpose (-12 to +12)\n- Capo (0-12 frets)\n- Settings presets (planned Sprint 4)\n- High contrast mode (planned Sprint 3)\n\n**Layout:** Slide-in from left, 384px width\n\n---\n\n#### 7. Header\n**File:** `frontend/components/Header.tsx`\n\n**Elements:**\n- Settings button (gear icon, cyan background)\n- Upload Song button\n- Demo button\n- Song title/artist display (center)\n\n---\n\n#### 8. ChordDiagram\n**File:** `frontend/components/ChordDiagram.tsx`\n\n**Purpose:** Guitar chord visualization\n\n**Elements:**\n- Fretboard grid\n- Finger positions\n- Chord name label\n\n---\n\n### Component Hierarchy\n\n```\nApp (State Manager)\n├── Header\n│   ├── Settings Button → Opens SettingsPanel\n│   ├── Upload Button → Triggers upload flow\n│   └── Song Title (center)\n│\n├── Main Content (View-Switched)\n│   ├── TeleprompterView (Performance Mode)\n│   │   ├── Audio Controls Bar ✨ NEW\n│   │   │   ├── StemSelector ✨ NEW\n│   │   │   └── AudioPlayer ✨ NEW\n│   │   └── Lyrics Display (Living Chart)\n│   │\n│   ├── Full Chart (Edit Mode)\n│   └── SongMapDemo\n│\n├── Footer\n│\n└── SettingsPanel (Modal)\n    └── LibraryView\n```\n\n---\n\n## 📋 Feature Status\n\n### ✅ Complete (Sprint 1-2)\n\n| Feature | Component | Status |\n|---------|-----------|--------|\n| **Teleprompter display** | TeleprompterView | ✅ Complete |\n| **Syllable highlighting** | TeleprompterView | ✅ Complete |\n| **Auto-scroll** | TeleprompterView | ✅ Complete |\n| **Chord display** | TeleprompterView | ✅ Complete |\n| **Audio playback** | AudioPlayer | ✅ Complete |\n| **Stem selection** | StemSelector | ✅ Complete |\n| **Progress bar** | AudioPlayer | ✅ Complete |\n| **Volume control** | AudioPlayer | ✅ Complete |\n| **Song Map generation** | Backend | ✅ Complete |\n| **Library management** | LibraryView | ✅ Complete |\n| **Settings panel** | SettingsPanel | ✅ Complete |\n| **Full Chart editor** | BlueprintView | ✅ Complete |\n\n### 🔨 In Progress\n\n| Feature | Target | Current | Sprint |\n|---------|--------|---------|--------|\n| **60fps rendering** | 60fps | 50fps | Sprint 3 |\n| **Settings speed** | <2s | ~4s | Sprint 3 |\n\n### 📋 Planned\n\n#### Sprint 3 (Oct 8-21): Performance & Accessibility\n- [ ] 60fps rendering optimization\n- [ ] Auto-center active line (50% viewport)\n- [ ] Keyboard navigation (8 shortcuts)\n- [ ] ARIA labels and semantic HTML\n- [ ] High contrast mode\n- [ ] Focus indicators\n- [ ] Reduced motion mode\n\n#### Sprint 4 (Oct 22 - Nov 4): Enhanced Editing + SongPrep Experimentation\n- [ ] Chord autocomplete popup\n- [ ] Drag-to-reorder sections\n- [ ] Real-time chord validation\n- [ ] Emergency font adjust (double-tap)\n- [ ] Library autocomplete search\n- [ ] Settings presets\n- [ ] **SongPrep Integration Research** (NEW)\n  - [ ] Clone SongPrep repository and set up environment\n  - [ ] Download 7B model weights from HuggingFace\n  - [ ] Test on 10 sample songs\n  - [ ] Benchmark inference speed and accuracy\n  - [ ] Compare section detection vs current heuristics\n  - [ ] Assess GPU requirements and resource impact\n  - [ ] Document findings and integration recommendations\n\n#### Sprint 5 (Nov 5-18): Polish & Testing + SongPrep Integration\n- [ ] Micro-interactions and animations\n- [ ] Loading states (skeleton screens)\n- [ ] User testing\n- [ ] Bug fixes and polish\n- [ ] **SongPrep Integration** (if Sprint 4 experiments successful)\n  - [ ] Create `backend/src/services/songprep/` module\n  - [ ] Implement parser for SongPrep output → Song Map format\n  - [ ] Update orchestrator for parallel processing\n  - [ ] Add confidence scoring to sections\n  - [ ] E2E testing: Audio → SongPrep → Living Chart\n  - [ ] Performance optimization (GPU, caching)\n\n### 🔮 Future (Post-MVP)\n\n- **Phase 2 (Q1 2026):** Setlist management, mobile support, SongPrep fine-tuning\n- **Phase 3 (Q2 2026):** Collaborative editing, cloud sync, genre-specific structure models\n- **Phase 4 (Q3 2026):** AI accompaniment (drums, bass, keys)\n- **Phase 5 (Q4 2026):** Voice commands, custom training datasets\n\n---\n\n## 🗺️ Roadmap\n\n### MVP Timeline\n\n| Sprint | Dates | Theme | Deliverables |\n|--------|-------|-------|--------------|\n| **1-2** | ✅ Complete | Backend + Audio | Analysis pipeline, audio playback, stems |\n| **3** | Oct 8-21 | Performance + A11y | 60fps, keyboard nav, ARIA, high contrast |\n| **4** | Oct 22-Nov 4 | Enhanced Editing | Chord autocomplete, drag sections, emergency font |\n| **5** | Nov 5-18 | Polish + Testing | Animations, loading states, user testing |\n| **MVP** | Nov 22 | Launch | Feature complete, accessible, bug-free |\n\n### Sprint 3 Breakdown (Oct 8-21)\n\n**Week 1: Performance**\n1. Optimize TeleprompterView rendering (virtual scrolling)\n2. Add syllable pulse animation\n3. Implement auto-centering (50% viewport)\n\n**Week 2: Accessibility**\n1. Keyboard navigation (8 shortcuts)\n2. ARIA labels on all elements\n3. High contrast mode\n4. Focus indicators\n\n**Acceptance Criteria:**\n- [ ] 60fps sustained for 10-min song\n- [ ] All elements keyboard accessible\n- [ ] WCAG AAA contrast ratios\n- [ ] Lighthouse accessibility score: 95+\n\n---\n\n## 🔧 Developer Guide\n\n### Project Structure\n\n```\nPerformia/\n├── frontend/                  # React frontend\n│   ├── components/           # React components\n│   ├── services/             # Library service, etc.\n│   ├── hooks/                # Custom hooks\n│   ├── data/                 # Mock data\n│   ├── types.ts              # TypeScript definitions\n│   └── index.css             # Global styles\n│\n├── backend/                   # Python backend\n│   ├── src/\n│   │   ├── main.py           # FastAPI server\n│   │   ├── services/         # Audio analysis\n│   │   └── schemas/          # JSON schemas\n│   └── requirements.txt\n│\n└── PERFORMIA_MASTER_DOCS.md  # This file\n```\n\n### Development Workflow\n\n1. **Start Backend:**\n   ```bash\n   cd backend\n   python src/main.py\n   ```\n\n2. **Start Frontend:**\n   ```bash\n   cd frontend\n   npm run dev\n   ```\n\n3. **Make Changes:**\n   - Hot reload enabled (Vite)\n   - Backend restarts on file change\n\n4. **Test:**\n   ```bash\n   # Frontend\n   npm test\n\n   # Backend\n   pytest\n   ```\n\n5. **Commit:**\n   ```bash\n   git add .\n   git commit -m \"feat: description\"\n   git push\n   ```\n\n### Key Files to Know\n\n| File | Purpose |\n|------|---------|\n| `frontend/App.tsx` | Main app component, state management |\n| `frontend/components/TeleprompterView.tsx` | Living Chart display |\n| `frontend/components/AudioPlayer.tsx` | Audio playback controls |\n| `frontend/types.ts` | TypeScript type definitions |\n| `backend/src/main.py` | FastAPI server, routes |\n| `backend/schemas/song_map.schema.json` | Song Map structure |\n\n### Adding a New Component\n\n1. Create file in `frontend/components/`\n2. Define TypeScript interface for props\n3. Implement component with accessibility (ARIA labels)\n4. Add to parent component\n5. Update this documentation\n\n### Debugging Tips\n\n**Frontend:**\n- React DevTools for component tree\n- Console.log sparingly (use breakpoints)\n- Check Network tab for API calls\n\n**Backend:**\n- FastAPI auto-docs: `http://localhost:8000/docs`\n- Check logs for errors\n- Use Python debugger (pdb)\n\n**Performance:**\n- Chrome DevTools Performance tab\n- Target: 60fps (16.67ms per frame)\n- Check for layout thrashing\n\n---\n\n## ♿ Accessibility\n\n### WCAG Compliance\n\n**Target:** WCAG 2.1 AA minimum, AAA for critical elements\n\n### Contrast Ratios\n\n| Element | Ratio | Standard |\n|---------|-------|----------|\n| Lyrics | 16:1 | AAA |\n| Chords | 7:1 | AAA |\n| UI Controls | 4.5:1 | AA |\n\n### Keyboard Navigation\n\n| Key | Action | Context |\n|-----|--------|---------|\n| **Space** | Play/pause | Teleprompter |\n| **←/→** | Prev/next section | Teleprompter |\n| **Cmd+,** | Open settings | Global |\n| **Cmd+L** | Open library | Global |\n| **Cmd+E** | Toggle edit mode | Global |\n| **Esc** | Close modal | Global |\n| **Tab** | Navigate controls | Settings |\n| **Cmd+↑/↓** | Font size ±10% | Teleprompter |\n\n### Screen Reader Support\n\n- Semantic HTML (`<header>`, `<main>`, `<nav>`)\n- ARIA labels on all interactive elements\n- ARIA live regions for dynamic content\n- Announce section changes and playback state\n\n### Visual Accessibility\n\n- **High contrast mode** (black-on-white toggle)\n- **Focus indicators** (2px cyan outline)\n- **Reduced motion** (disable animations)\n- **Minimum touch targets** (44x44px)\n\n### Testing Checklist\n\n- [ ] Tab through all interactive elements\n- [ ] Test with screen reader (VoiceOver/NVDA)\n- [ ] Check contrast with WCAG Color Contrast Checker\n- [ ] Test reduced motion preference\n- [ ] Verify focus indicators visible\n\n---\n\n## 📊 Success Metrics\n\n### Quantitative Targets\n\n| Metric | Target | Current | Status |\n|--------|--------|---------|--------|\n| **Time to first performance** | <30s | ✅ 25s | ✅ Met |\n| **Song search speed** | <5s | ✅ 3s | ✅ Met |\n| **Settings adjust speed** | <2s | 🔨 4s | 🔨 In progress |\n| **Frame rate** | 60fps | 🔨 50fps | 🔨 In progress |\n| **Audio latency** | <50ms | ✅ 35ms | ✅ Met |\n| **Analysis speed** | <30s/song | ✅ 22s | ✅ Met |\n| **Chord accuracy** | 90%+ | ✅ 92% | ✅ Met |\n| **Lyric accuracy** | 95%+ | ✅ 96% | ✅ Met |\n\n### Qualitative Targets\n\n- **Ease of use:** 4.5+ stars (out of 5)\n- **Feature discovery:** 80%+ without tutorial\n- **Visual clarity:** 95%+ \"easy to read\"\n- **Performance satisfaction:** 90%+ \"feels instant\"\n\n### Analytics to Track\n\n1. Time to first performance\n2. Songs uploaded per user\n3. Most used features\n4. Error rate\n5. Session duration\n6. Return rate (weekly active)\n\n---\n\n## 🔍 Frequently Asked Questions\n\n### General\n\n**Q: What audio formats are supported?**\nA: WAV, MP3, M4A, FLAC\n\n**Q: How long does song analysis take?**\nA: ~30 seconds per song (varies by length)\n\n**Q: Can I edit the auto-generated chords?**\nA: Yes, use Full Chart to edit chords inline\n\n**Q: Does it work offline?**\nA: Not yet (planned for Phase 3)\n\n### Technical\n\n**Q: Why 60fps target?**\nA: Smooth scrolling is critical for reading during performance. 60fps = 16.67ms per frame.\n\n**Q: Canvas vs DOM for rendering?**\nA: Currently DOM. Will optimize first, consider Canvas only if needed (accessibility trade-off).\n\n**Q: How does syllable sync work?**\nA: RequestAnimationFrame checks current audio time, finds matching syllable, updates highlight.\n\n**Q: Why Performia cyan?**\nA: High contrast with warm amber chords, signals \"now\", cool color stands out.\n\n---\n\n## 📝 Contribution Guidelines\n\n### Code Style\n\n- **TypeScript:** Strict mode, explicit types\n- **React:** Functional components, hooks\n- **CSS:** Tailwind utility classes, avoid inline styles\n- **Naming:** camelCase for variables, PascalCase for components\n\n### Commit Messages\n\n```\nfeat: Add emergency font adjust gesture\nfix: Resolve audio sync latency issue\ndocs: Update component API reference\nrefactor: Optimize TeleprompterView rendering\ntest: Add unit tests for chord validation\n```\n\n### Pull Requests\n\n1. Create feature branch: `git checkout -b feat/my-feature`\n2. Make changes and commit\n3. Push: `git push -u origin feat/my-feature`\n4. Open PR with description\n5. Request review\n6. Merge after approval\n\n---\n\n## 🐛 Known Issues & Limitations\n\n### Current Limitations\n\n1. **Desktop only** (mobile support in Phase 2)\n2. **Local storage** (no cloud sync yet)\n3. **No collaboration** (single user editing)\n4. **English lyrics only** (multi-language in future)\n\n### Known Bugs\n\n*None currently tracked for MVP*\n\n### Workarounds\n\n**Issue:** Font size changes lag\n**Workaround:** Use preset sizes instead of slider\n\n**Issue:** Large songs (>10min) slow down\n**Workaround:** Virtual scrolling coming in Sprint 3\n\n---\n\n## 📚 Additional Resources\n\n### External Links\n\n- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)\n- [React Performance](https://react.dev/learn/render-and-commit)\n- [Tailwind CSS Docs](https://tailwindcss.com/docs)\n- [FastAPI Docs](https://fastapi.tiangolo.com/)\n- **[SongPrep Repository](https://github.com/tencent-ailab/SongPrep)** - Song structure parsing\n- **[SongPrep Paper](https://arxiv.org/abs/2509.17404)** - Technical details\n\n### Internal Files\n\n- `backend/schemas/song_map.schema.json` - Song Map structure\n- `frontend/types.ts` - TypeScript definitions\n- `.claude/CLAUDE.md` - Agent SDK instructions\n- **`docs/research/SONGPREP_ANALYSIS.md`** - SongPrep integration research\n\n---\n\n## 📅 Document History\n\n| Version | Date | Changes |\n|---------|------|---------|\n| 3.0 | Oct 1, 2025 | Consolidated all docs into master file |\n| 2.0 | Oct 1, 2025 | Added AudioPlayer & StemSelector specs |\n| 1.0 | Sep 30, 2025 | Initial documentation structure |\n\n---\n\n## 🎯 Core Principle\n\n> **\"The best interface for performance is no interface at all.\"**\n\nEvery decision must answer:\n**\"Does this help the musician perform better, or does it distract?\"**\n\nIf it distracts → Cut it.\nIf it helps → Polish it until it's invisible.\n\n---\n\n**Maintained by:** Performia Development Team\n**Next Review:** End of Sprint 3 (Oct 21, 2025)\n**Questions?** Check the FAQ or open an issue\n"
+}

--- a/ui/server/viztrtr-workspaces/proj_1759612427153_69yod81/product-spec.json
+++ b/ui/server/viztrtr-workspaces/proj_1759612427153_69yod81/product-spec.json
@@ -1,0 +1,583 @@
+{
+  "projectId": "proj_1759612427153_69yod81",
+  "version": 1,
+  "createdAt": "2025-10-04T21:31:24.031Z",
+  "lastUpdated": "2025-10-04T21:31:24.031Z",
+  "productVision": "Performia is a revolutionary music performance system that transforms live performance by combining real-time audio analysis with an intelligent Living Chart teleprompter, enabling musicians to focus entirely on their artistry without worrying about forgetting lyrics or chords.",
+  "targetUsers": [
+    "Live performers (vocalists, guitarists, bands) performing 3-4 gigs per week who need large fonts readable from 6ft away with zero distractions",
+    "Rehearsal musicians learning new songs who need to edit chords and structure while practicing with isolated stems",
+    "Casual hobbyists practicing at home who need a simple, intuitive interface to explore and learn demo songs"
+  ],
+  "components": {
+    "TeleprompterView": {
+      "purpose": "Fullscreen lyrics display with real-time syllable highlighting and auto-scrolling, serving as the primary performance interface",
+      "userStories": [
+        "As a live performer, I need lyrics that highlight in real-time as I sing so I never lose my place during performance",
+        "As a vocalist, I need the active line centered on screen so I can read ahead without head movement",
+        "As a guitarist, I need chords displayed above lyrics with customizable visibility so I can reference them without distraction",
+        "As a stage performer, I need fonts large enough to read from 6ft away so I can perform without stepping closer to the screen"
+      ],
+      "designPriorities": [
+        "Maximum legibility",
+        "Zero-latency feel",
+        "Minimal visual distraction",
+        "Performance readiness"
+      ],
+      "focusAreas": [
+        "Font size control with 50%-150% range (2.5rem to 6rem)",
+        "Real-time syllable highlighting with cyan glow effect",
+        "Auto-scroll with active line centered at 50% viewport",
+        "High contrast color scheme (near-black background, cool white text)",
+        "Chord display positioning and sizing relative to lyrics (80% ratio)",
+        "Past lyrics opacity reduction (30%) for visual hierarchy",
+        "60fps sustained rendering for smooth scrolling"
+      ],
+      "avoidAreas": [
+        "Complex animations during active performance",
+        "UI chrome or controls overlaying lyrics area",
+        "Automatic font size adjustments without user control",
+        "Distracting transition effects between sections"
+      ],
+      "acceptanceCriteria": [
+        "Font size minimum 2.5rem, default 3.5rem, maximum 6rem",
+        "Syllable highlight latency under 50ms from audio playback",
+        "Active line maintains 50% viewport position during auto-scroll",
+        "60fps sustained for 10-minute song duration",
+        "WCAG AAA contrast ratio (16:1) for lyrics text",
+        "Chord visibility toggles between off, names, and diagrams",
+        "Readable from 6ft distance in stage lighting conditions"
+      ],
+      "status": "active"
+    },
+    "AudioPlayer": {
+      "purpose": "Full-featured audio playback controls with progress tracking, volume control, and real-time sync with lyrics display",
+      "userStories": [
+        "As a performer, I need play/pause controls that respond instantly so I can control playback without interrupting my flow",
+        "As a rehearsal musician, I need to seek to specific song sections quickly so I can practice difficult parts",
+        "As a user, I need volume control with mute option so I can adjust audio levels without leaving performance mode",
+        "As a performer, I need to see current time and total duration so I can pace my performance"
+      ],
+      "designPriorities": [
+        "Instant responsiveness",
+        "Visual clarity",
+        "Touch-friendly controls",
+        "Status visibility"
+      ],
+      "focusAreas": [
+        "Large play/pause button with clear icon states (play ▶, pause ⏸)",
+        "Draggable progress bar with cyan fill and precise seeking",
+        "Volume slider with mute toggle and clear audio level icons",
+        "Monospace time display for consistent width (MM:SS format)",
+        "Container styling with gray-800 background and 8px radius",
+        "Real-time sync callback to parent component for syllable tracking",
+        "Loading and buffering state indicators"
+      ],
+      "avoidAreas": [
+        "Auto-play without user interaction",
+        "Complex playback controls that clutter the interface",
+        "Abrupt audio transitions without fade effects",
+        "Hidden volume controls requiring hover or long-press"
+      ],
+      "acceptanceCriteria": [
+        "Play/pause response time under 100ms",
+        "Progress bar draggable with 1-second precision",
+        "Volume control range 0.0 to 1.0 with smooth adjustment",
+        "Audio latency under 50ms from control interaction",
+        "Time display updates every 100ms during playback",
+        "Minimum touch target size 44x44px for all controls",
+        "Keyboard accessible (Space for play/pause)"
+      ],
+      "status": "active"
+    },
+    "StemSelector": {
+      "purpose": "Audio stem selection interface allowing users to toggle between full mix, vocals, bass, drums, and other instrumental tracks",
+      "userStories": [
+        "As a rehearsal musician, I need to isolate vocal stems so I can practice singing without competing with original vocals",
+        "As a bass player, I need to mute bass stems so I can practice my parts with the rest of the band",
+        "As a user, I need to see which stems are available before selecting so I know what isolation options exist",
+        "As a performer, I need instant stem switching so I can adapt my practice session without interruption"
+      ],
+      "designPriorities": [
+        "Availability transparency",
+        "Fast switching",
+        "Clear active state",
+        "Loading feedback"
+      ],
+      "focusAreas": [
+        "5 stem type buttons (Full Mix, Vocals, Bass, Drums, Other)",
+        "Visual distinction between selected, unselected, loading, and unavailable states",
+        "Selected state with cyan background, black text, 105% scale, and play icon",
+        "Loading state with 50% opacity and spinning clock icon",
+        "Unavailable state with 60% opacity and disabled interaction",
+        "HEAD request availability check before display",
+        "Smooth state transitions between stems"
+      ],
+      "avoidAreas": [
+        "Automatic stem selection without user choice",
+        "Hidden stem availability information",
+        "Slow stem loading without progress feedback",
+        "Confusing button states or unclear labels"
+      ],
+      "acceptanceCriteria": [
+        "All 5 stem types displayed with clear labels",
+        "Availability check completes in under 2 seconds",
+        "Selected state visually distinct with cyan background and scale effect",
+        "Loading spinner visible during stem fetch (estimated 1-3 seconds)",
+        "Unavailable stems clearly marked and non-interactive",
+        "Stem switch response time under 500ms after availability confirmation",
+        "Keyboard accessible with arrow key navigation"
+      ],
+      "status": "active"
+    },
+    "FullChart": {
+      "purpose": "Document-style song editor for viewing and editing complete song structure, lyrics, chords, and metadata",
+      "userStories": [
+        "As a rehearsal musician, I need to edit auto-generated chords inline so I can correct mistakes without leaving the app",
+        "As a song arranger, I need to add, remove, and reorder sections so I can customize song structure for my performance",
+        "As a user, I need to edit song title, artist, key, and BPM metadata so I can keep my library organized",
+        "As a musician, I need to see the complete song structure at once so I can understand arrangement and flow"
+      ],
+      "designPriorities": [
+        "Inline editability",
+        "Clear structure visualization",
+        "Efficient editing workflow",
+        "Data persistence"
+      ],
+      "focusAreas": [
+        "Editable title and artist fields with click-to-edit interaction",
+        "Section headers (Verse, Chorus, Bridge) with visual hierarchy",
+        "Inline chord editing above lyrics with autocomplete (planned Sprint 4)",
+        "Drag handles for section reordering (planned Sprint 4)",
+        "Add section button with section type selection",
+        "Real-time chord validation and suggestions",
+        "Document-style layout with comfortable reading width"
+      ],
+      "avoidAreas": [
+        "Complex WYSIWYG editor features that slow down editing",
+        "Modal dialogs for simple edits",
+        "Auto-save without user awareness or undo capability",
+        "Overwhelming formatting options that distract from content"
+      ],
+      "acceptanceCriteria": [
+        "Click any text field to enable inline editing",
+        "Chord autocomplete popup appears within 200ms of typing",
+        "Section reordering via drag completes in under 1 second",
+        "Changes persist to Song Map JSON immediately",
+        "Undo/redo supports last 20 actions",
+        "Keyboard shortcuts for common edits (Cmd+B for bold chord, etc.)",
+        "Validation prevents invalid chord names or structure"
+      ],
+      "status": "active"
+    },
+    "LibraryView": {
+      "purpose": "Song search and library management interface for browsing, filtering, and organizing uploaded songs",
+      "userStories": [
+        "As a performer, I need to search songs by title or artist instantly so I can find songs quickly before a gig",
+        "As a user, I need to filter songs by key, BPM, or genre so I can build setlists with compatible songs",
+        "As a library manager, I need to see song metadata on cards so I can identify songs at a glance",
+        "As a performer, I need quick actions (Play, Edit, Delete) on song cards so I can manage my library efficiently"
+      ],
+      "designPriorities": [
+        "Search speed",
+        "Filter clarity",
+        "Metadata visibility",
+        "Quick actions"
+      ],
+      "focusAreas": [
+        "Instant search with fuzzy matching across title, artist, lyrics, and tags",
+        "Filter controls for genre, key, BPM range, and difficulty level",
+        "Sort options (title, date added, last played, BPM)",
+        "Song card layout with thumbnail, title, artist, key, BPM, and duration",
+        "Quick action buttons (Play, Edit, Delete) on hover or touch",
+        "Grid or list view toggle for user preference",
+        "Search autocomplete suggestions (planned Sprint 4)"
+      ],
+      "avoidAreas": [
+        "Slow search results requiring server round-trip",
+        "Complex filter UI that requires multiple steps",
+        "Hidden metadata requiring card expansion",
+        "Destructive actions without confirmation dialogs"
+      ],
+      "acceptanceCriteria": [
+        "Search results appear in under 100ms for local library",
+        "Fuzzy matching finds songs with 80% title/artist similarity",
+        "Filter application updates results in under 200ms",
+        "Song cards display 6 metadata fields minimum",
+        "Quick actions accessible with single click or tap",
+        "Keyboard navigation through search results with arrow keys",
+        "Delete action requires confirmation before execution"
+      ],
+      "status": "active"
+    },
+    "SettingsPanel": {
+      "purpose": "Slide-in panel for quick access to performance settings including font size, transpose, capo, and chord display options",
+      "userStories": [
+        "As a performer, I need to adjust font size quickly so I can optimize readability for different stage distances",
+        "As a guitarist, I need to transpose songs to match my vocal range without re-uploading the song",
+        "As a capo user, I need to indicate capo position so chord diagrams display correctly for my playing",
+        "As a user, I need to toggle chord visibility so I can practice lyrics-only or with chord reference"
+      ],
+      "designPriorities": [
+        "Quick access",
+        "Clear controls",
+        "Immediate preview",
+        "Settings persistence"
+      ],
+      "focusAreas": [
+        "Font size slider with 50%-150% range and live preview",
+        "Transpose control with -12 to +12 semitone range and key preview",
+        "Capo selector (0-12 frets) with chord diagram updates",
+        "Chord display mode toggle (Off, Names, Diagrams)",
+        "Settings presets for common configurations (planned Sprint 4)",
+        "High contrast mode toggle (planned Sprint 3)",
+        "Slide-in animation from left with 384px width"
+      ],
+      "avoidAreas": [
+        "Settings changes requiring page reload or re-analysis",
+        "Complex nested settings menus requiring multiple clicks",
+        "Settings without immediate visual feedback",
+        "Auto-apply settings without user confirmation"
+      ],
+      "acceptanceCriteria": [
+        "Settings panel opens in under 300ms with smooth slide animation",
+        "Font size changes apply instantly to teleprompter view",
+        "Transpose updates all chords within 500ms",
+        "Capo selection updates chord diagrams immediately",
+        "Settings persist to localStorage on change",
+        "Close button and Esc key both dismiss panel",
+        "All controls keyboard accessible with Tab navigation"
+      ],
+      "status": "active"
+    },
+    "Header": {
+      "purpose": "Primary navigation bar providing access to settings, upload, demo mode, and current song information",
+      "userStories": [
+        "As a user, I need quick access to settings from any view so I can adjust preferences without losing context",
+        "As a performer, I need to see the current song title at a glance so I know which song is loaded",
+        "As a new user, I need a demo button to explore features without uploading my own content",
+        "As a user, I need an upload button always visible so I can add new songs at any time"
+      ],
+      "designPriorities": [
+        "Persistent visibility",
+        "Clear navigation",
+        "Context awareness",
+        "Action accessibility"
+      ],
+      "focusAreas": [
+        "Settings button (gear icon) with cyan background on left side",
+        "Upload Song button with clear label and icon",
+        "Demo button for quick feature exploration",
+        "Centered song title and artist display with truncation for long names",
+        "Consistent height (60-80px) across all viewports",
+        "Responsive layout collapsing gracefully on smaller screens",
+        "Fixed position at top of viewport"
+      ],
+      "avoidAreas": [
+        "Auto-hiding header that requires scrolling to access",
+        "Cluttered button layouts with unclear priorities",
+        "Song title overflow without truncation or tooltip",
+        "Inconsistent button sizing or spacing"
+      ],
+      "acceptanceCriteria": [
+        "Header visible at all times regardless of scroll position",
+        "Settings button opens panel in under 300ms",
+        "Song title truncates with ellipsis after 40 characters with full text on hover",
+        "Upload button triggers file picker immediately on click",
+        "Demo button loads Yesterday demo song in under 2 seconds",
+        "All buttons minimum 44x44px touch target size",
+        "Keyboard accessible with Tab navigation and Enter activation"
+      ],
+      "status": "active"
+    },
+    "ChordDiagram": {
+      "purpose": "Visual guitar chord diagram showing finger positions on fretboard for chord reference during performance",
+      "userStories": [
+        "As a guitarist, I need to see finger positions for unfamiliar chords so I can play along accurately",
+        "As a learner, I need clear fretboard visualization so I understand where to place my fingers",
+        "As a performer, I need chord diagrams sized appropriately so they don't distract from lyrics",
+        "As a user, I need chord name labels so I can identify which chord the diagram represents"
+      ],
+      "designPriorities": [
+        "Visual clarity",
+        "Accurate positioning",
+        "Appropriate sizing",
+        "Quick recognition"
+      ],
+      "focusAreas": [
+        "Fretboard grid with 6 strings and 4-5 frets visible",
+        "Finger position dots with clear contrast against fretboard",
+        "Open string indicators (O) and muted string indicators (X) above nut",
+        "Chord name label positioned above diagram",
+        "Barre chord visualization with curved line connecting positions",
+        "Responsive sizing relative to lyric font size",
+        "Optional finger numbers (1-4) inside position dots"
+      ],
+      "avoidAreas": [
+        "Overly complex diagrams with advanced notation (palm muting, harmonics)",
+        "Diagrams larger than necessary that compete with lyrics",
+        "Color coding that relies on hue alone (accessibility issue)",
+        "Animated diagrams that distract during performance"
+      ],
+      "acceptanceCriteria": [
+        "Diagram renders in under 100ms when chord changes",
+        "Finger positions clearly visible from 6ft distance",
+        "Contrast ratio of 4.5:1 minimum between dots and background",
+        "Chord name label matches transposed key accurately",
+        "Barre chords indicated with connecting line across frets",
+        "Diagram width scales to 80% of chord name text size",
+        "SVG-based for crisp rendering at any zoom level"
+      ],
+      "status": "active"
+    },
+    "UploadFlow": {
+      "purpose": "Multi-step interface guiding users through audio file upload, analysis progress, and Song Map generation",
+      "userStories": [
+        "As a user, I need to upload audio files via drag-and-drop or file picker so I can add songs quickly",
+        "As a user, I need to see analysis progress in real-time so I know how long to wait",
+        "As a user, I need clear error messages if upload fails so I can troubleshoot issues",
+        "As a user, I need to be notified when analysis completes so I can start performing immediately"
+      ],
+      "designPriorities": [
+        "Clear progress feedback",
+        "Error handling",
+        "File validation",
+        "Seamless transition"
+      ],
+      "focusAreas": [
+        "Drag-and-drop zone with hover state and visual feedback",
+        "File type validation (WAV, MP3, M4A, FLAC) with error messaging",
+        "Progress bar showing analysis stages (Upload, Stem Separation, Lyrics, Chords)",
+        "Estimated time remaining based on file size",
+        "Cancel button for long-running analysis",
+        "Success state with automatic navigation to song view",
+        "Error state with retry option and support link"
+      ],
+      "avoidAreas": [
+        "Silent failures without user notification",
+        "Progress indicators without stage breakdown",
+        "Auto-navigation before user is ready to view song",
+        "File size limits without clear communication"
+      ],
+      "acceptanceCriteria": [
+        "Drag-and-drop zone accepts files with visual highlight on hover",
+        "File validation rejects unsupported formats with clear error message",
+        "Progress bar updates every 2 seconds during analysis",
+        "Analysis completes in under 30 seconds for 3-minute song",
+        "Success notification appears with Continue to Song button",
+        "Cancel button stops analysis and returns to previous view",
+        "Error messages include retry button and error code for support"
+      ],
+      "status": "active"
+    },
+    "AudioControlBar": {
+      "purpose": "Consolidated audio controls container housing AudioPlayer and StemSelector in a unified interface above lyrics",
+      "userStories": [
+        "As a performer, I need all audio controls in one location so I can manage playback without searching",
+        "As a rehearsal musician, I need quick access to both playback and stem selection so I can switch modes efficiently",
+        "As a user, I need the control bar to be unobtrusive so it doesn't block lyrics during performance",
+        "As a user, I need the control bar to remain accessible when scrolling so I can pause at any time"
+      ],
+      "designPriorities": [
+        "Unified control location",
+        "Minimal footprint",
+        "Persistent accessibility",
+        "Visual hierarchy"
+      ],
+      "focusAreas": [
+        "Fixed height (120-180px) with responsive adjustment",
+        "Gray-900 background with subtle bottom border for separation",
+        "Horizontal layout with StemSelector on left, AudioPlayer on right",
+        "Sticky positioning at top of teleprompter view",
+        "Collapsible option for full-screen performance mode",
+        "Smooth show/hide animation on user interaction",
+        "Touch-friendly spacing between controls"
+      ],
+      "avoidAreas": [
+        "Overlapping lyrics text during auto-scroll",
+        "Auto-hiding that requires precise mouse positioning to reveal",
+        "Controls that rearrange based on viewport size causing confusion",
+        "Excessive visual styling that draws attention away from lyrics"
+      ],
+      "acceptanceCriteria": [
+        "Control bar height between 120-180px based on content",
+        "Sticky positioning maintains visibility during scroll",
+        "Controls remain interactive with minimum 44x44px touch targets",
+        "Show/hide animation completes in under 300ms",
+        "Keyboard shortcut (Cmd+H) toggles visibility instantly",
+        "Bar collapses gracefully on narrow viewports (under 768px)",
+        "Visual separation from lyrics with 1px border and 16px padding"
+      ],
+      "status": "active"
+    },
+    "EmergencyFontAdjust": {
+      "purpose": "Quick gesture-based font size adjustment during live performance for emergency readability fixes",
+      "userStories": [
+        "As a live performer, I need to increase font size mid-song if I can't read lyrics so I don't forget lines",
+        "As a user in bright stage lighting, I need quick contrast adjustment so I can see lyrics without stopping",
+        "As a performer, I need font adjustments that don't interrupt playback so I can fix issues seamlessly",
+        "As a user, I need gesture controls that don't conflict with other interactions so I don't trigger them accidentally"
+      ],
+      "designPriorities": [
+        "Instant response",
+        "Non-disruptive interaction",
+        "Clear visual feedback",
+        "Fail-safe design"
+      ],
+      "focusAreas": [
+        "Double-tap gesture on teleprompter to increase font 10%",
+        "Two-finger pinch gesture for precise sizing (mobile)",
+        "Keyboard shortcut (Cmd+↑/↓) for 10% increments",
+        "Visual feedback overlay showing new font size percentage",
+        "Maximum font size limit (150%) to prevent layout breaks",
+        "Temporary feedback that fades after 1 second",
+        "No confirmation required for quick adjustments"
+      ],
+      "avoidAreas": [
+        "Gestures that conflict with scroll or selection interactions",
+        "Modal dialogs requiring confirmation that interrupt performance",
+        "Font changes that cause layout reflow and lose scroll position",
+        "Overly sensitive gesture detection causing accidental triggers"
+      ],
+      "acceptanceCriteria": [
+        "Double-tap increases font by 10% within 100ms",
+        "Pinch gesture adjusts font with 1:1 tracking of finger movement",
+        "Keyboard shortcut responds with zero perceptible delay",
+        "Visual feedback overlay appears for 1 second then fades smoothly",
+        "Font size capped at 150% (6rem) with user notification",
+        "Gesture detection requires minimum 100ms between taps to prevent accidental triggers",
+        "Layout maintains scroll position after font size change"
+      ],
+      "status": "planned"
+    },
+    "KeyboardShortcuts": {
+      "purpose": "Comprehensive keyboard navigation system for hands-free control during performance and efficient editing",
+      "userStories": [
+        "As a performer, I need to control playback without touching the mouse so I can keep my hands on my instrument",
+        "As a power user, I need keyboard shortcuts for common actions so I can work more efficiently",
+        "As an accessibility user, I need full keyboard navigation so I can use the app without a mouse",
+        "As a user, I need discoverable shortcuts with visual hints so I can learn them over time"
+      ],
+      "designPriorities": [
+        "Full coverage of primary actions",
+        "Standard shortcut conventions",
+        "Visual discoverability",
+        "No conflicts with browser shortcuts"
+      ],
+      "focusAreas": [
+        "8 primary shortcuts (Space, ←/→, Cmd+comma, Cmd+L, Cmd+E, Esc, Tab, Cmd+↑/↓)",
+        "Shortcut hint overlay (Cmd+/ to toggle visibility)",
+        "Visual indicators on buttons showing keyboard shortcuts",
+        "Context-aware shortcuts (different actions in teleprompter vs edit mode)",
+        "Focus management ensuring shortcuts reach correct component",
+        "Modifier key support (Cmd/Ctrl, Shift, Alt) for advanced actions",
+        "Shortcut customization in settings (future enhancement)"
+      ],
+      "avoidAreas": [
+        "Shortcuts that conflict with browser or OS-level commands",
+        "Hidden shortcuts with no visual documentation",
+        "Context-free shortcuts that behave unpredictably",
+        "Single-key shortcuts that conflict with text input"
+      ],
+      "acceptanceCriteria": [
+        "All 8 primary shortcuts respond within 50ms",
+        "Cmd+/ toggles shortcut overlay with complete list in under 200ms",
+        "Visual indicators appear on hover for all shortcut-enabled buttons",
+        "Shortcuts respect focus context (work in correct component)",
+        "No conflicts with browser shortcuts (Cmd+T, Cmd+W, etc.)",
+        "Shortcut overlay dismisses with Esc or click outside",
+        "Screen reader announces shortcut availability on button focus"
+      ],
+      "status": "planned"
+    },
+    "HighContrastMode": {
+      "purpose": "Accessibility mode providing maximum contrast color scheme for users with visual impairments or bright stage lighting",
+      "userStories": [
+        "As a user with low vision, I need maximum contrast so I can read lyrics clearly",
+        "As a performer in bright stage lighting, I need high contrast mode so glare doesn't wash out the display",
+        "As a user sensitive to light, I need to toggle between normal and high contrast so I can adapt to different environments",
+        "As an accessibility user, I need high contrast to persist across sessions so I don't have to re-enable it"
+      ],
+      "designPriorities": [
+        "WCAG AAA compliance",
+        "User preference persistence",
+        "Clear toggle control",
+        "Consistent styling"
+      ],
+      "focusAreas": [
+        "Pure black background (rgb(0, 0, 0)) for maximum contrast",
+        "Pure white text (rgb(255, 255, 255)) for lyrics and primary content",
+        "Yellow highlights (rgb(255, 255, 0)) for active syllables",
+        "Bold weight increase for all text elements",
+        "Thicker borders (3px vs 1px) for UI elements",
+        "Toggle control in Settings panel with icon indicator",
+        "Respects prefers-contrast: high media query for auto-enable"
+      ],
+      "avoidAreas": [
+        "Subtle color variations that reduce contrast",
+        "Gradient backgrounds that introduce mid-tones",
+        "Thin fonts or stroke weights that reduce legibility",
+        "Auto-switching based on time of day without user control"
+      ],
+      "acceptanceCriteria": [
+        "Text contrast ratio of 21:1 (maximum) for all content",
+        "Toggle switch in Settings labeled High Contrast Mode",
+        "Mode persists to localStorage and applies on app load",
+        "All UI elements maintain 7:1 minimum contrast in high contrast mode",
+        "Icon indicator in header shows when high contrast is active",
+        "Transition to high contrast completes in under 200ms",
+        "Respects system preference if set before manual toggle"
+      ],
+      "status": "planned"
+    }
+  },
+  "globalConstraints": {
+    "accessibility": [
+      "WCAG 2.1 AA minimum compliance, AAA for critical elements (lyrics, chords)",
+      "Keyboard navigation for all interactive elements with visible focus indicators (2px cyan outline)",
+      "Screen reader support with semantic HTML and ARIA labels on all components",
+      "ARIA live regions for dynamic content updates (playback state, section changes)",
+      "Minimum touch target size 44x44px for all interactive elements",
+      "High contrast mode available for users with low vision",
+      "Reduced motion support respecting prefers-reduced-motion media query",
+      "Alternative text for all non-decorative images and icons",
+      "Color not used as sole indicator of meaning (supplemented with icons/text)"
+    ],
+    "performance": [
+      "60fps sustained rendering during teleprompter scrolling and syllable highlighting",
+      "Under 100ms perceived interaction time for all user actions",
+      "Audio latency under 50ms from playback control to sound output",
+      "Analysis completes in under 30 seconds per 3-minute song",
+      "Settings changes apply instantly without page reload (under 2 seconds)",
+      "Song search results return in under 100ms for local library (up to 1000 songs)",
+      "First meaningful paint under 1.5 seconds on 3G connection",
+      "Lighthouse performance score 90+ for production build",
+      "Virtual scrolling for large song lists (over 100 items)",
+      "Debounced user input (200ms) for search and filter operations"
+    ],
+    "browser": [
+      "Chrome 90+ (primary target)",
+      "Safari 14+ (macOS and iOS)",
+      "Firefox 88+",
+      "Edge 90+",
+      "Desktop: Windows 10+, macOS 11+, Ubuntu 20.04+",
+      "Minimum viewport: 1024x768 (desktop), 375x667 (mobile future support)",
+      "Web Audio API required for audio playback and stem mixing",
+      "localStorage for preferences and library metadata",
+      "No IE11 support (uses modern ES6+ features)"
+    ],
+    "design": [
+      "Performance-first design philosophy: UI disappears during performance",
+      "Dark theme optimized for stage environments (near-black backgrounds)",
+      "Performia cyan (rgb(6, 182, 212)) as primary accent color",
+      "Typography scale: 3.5rem default lyrics, 2.8rem chords, 1.125rem UI body text",
+      "Spacing system: 4px, 8px, 16px, 24px, 32px, 48px increments",
+      "Border radius: 4px (small), 8px (medium), 12px (large), 16px (extra-large)",
+      "Shadow system using rgba with multiple elevations for depth",
+      "Progressive disclosure: complexity hidden until needed",
+      "Musician mental model: sections, keys, chords as primary navigation concepts",
+      "Consistent component styling with Tailwind CSS utility classes"
+    ]
+  },
+  "originalPRD": "# 🎵 Performia - Complete Documentation\n\n**Version:** 3.0\n**Last Updated:** October 1, 2025\n**Status:** Living Document\n\n---\n\n## 📖 Table of Contents\n\n### Quick Navigation\n- [🎯 Product Overview](#-product-overview)\n- [🚀 Quick Start](#-quick-start)\n- [🏗️ Architecture](#️-architecture)\n- [🎨 Design System](#-design-system)\n- [🧩 Component Library](#-component-library)\n- [📋 Feature Status](#-feature-status)\n- [🗺️ Roadmap](#️-roadmap)\n- [🔧 Developer Guide](#-developer-guide)\n- [♿ Accessibility](#-accessibility)\n- [📊 Success Metrics](#-success-metrics)\n\n---\n\n## 🎯 Product Overview\n\n### What is Performia?\n\n**Performia** is a revolutionary music performance system that transforms how musicians perform live. By combining real-time audio analysis, AI-powered audio processing, and an intelligent \"Living Chart\" teleprompter, Performia enables musicians to focus on their artistry.\n\n**Core Value Proposition:**\n*\"Never forget lyrics or chords again. Performia follows YOU in real-time.\"*\n\n### Target Users\n\n1. **Live Performers** (Primary)\n   - Vocalists, guitarists, bands\n   - Perform 3-4 gigs per week\n   - Need large fonts readable from 6ft away\n   - Zero distractions during performance\n\n2. **Rehearsal Musicians** (Secondary)\n   - Learning new songs\n   - Need to edit chords and structure\n   - Practice with isolated stems\n\n3. **Casual Hobbyists** (Tertiary)\n   - Home practice\n   - Need simple, intuitive interface\n   - Explore demo songs\n\n### Design Philosophy\n\n> **\"The best interface for performance is no interface at all.\"**\n\n**Core Principles:**\n1. **Performance-First**: UI disappears during performance\n2. **Zero-Latency Feel**: <100ms perceived interaction time\n3. **Musician Mental Model**: Sections, keys, chords\n4. **Progressive Disclosure**: Complexity hidden until needed\n5. **Accessibility by Default**: Works for all musicians\n\n---\n\n## 🚀 Quick Start\n\n### Running Performia\n\n#### Backend (Python + C++)\n```bash\ncd backend\npython -m venv venv\nsource venv/bin/activate  # On Windows: venv\\Scripts\\activate\npip install -r requirements.txt\npython src/main.py\n```\n\nBackend runs on: `http://localhost:8000`\n\n#### Frontend (React + Vite)\n```bash\ncd frontend\nnpm install\nnpm run dev\n```\n\nFrontend runs on: `http://localhost:5001`\n\n### First-Time User Flow\n\n1. **Open Performia** → Demo song \"Yesterday\" loads automatically\n2. **Click Settings** (gear icon) → Adjust font size, transpose\n3. **Click Play** → Watch syllables highlight in real-time\n4. **Upload Song** → Drop audio file, wait ~30s for analysis\n5. **Perform** → Fullscreen lyrics with chords, zero distractions\n\n---\n\n## 🏗️ Architecture\n\n### Tech Stack\n\n**Frontend:**\n- React 19 + TypeScript 5\n- Vite 6 (build tool)\n- Tailwind CSS 4 (styling)\n- React hooks (state management)\n\n**Backend:**\n- Python 3.11 + FastAPI\n- JUCE (C++ audio engine)\n- Librosa (audio analysis)\n- Demucs (stem separation)\n- Whisper (speech recognition / ASR)\n- **SongPrep** (planned - song structure parsing)\n\n### Data Flow\n\n```\n1. Upload Audio → Backend\n2. Analysis Pipeline → Song Map JSON\n3. Frontend → Display Living Chart\n4. Audio Playback → Syllable Sync\n```\n\n### Song Map Schema\n\n```json\n{\n  \"title\": \"Song Title\",\n  \"artist\": \"Artist Name\",\n  \"key\": \"C Major\",\n  \"bpm\": 120,\n  \"sections\": [\n    {\n      \"name\": \"Verse 1\",\n      \"lines\": [\n        {\n          \"syllables\": [\n            {\n              \"text\": \"Hello\",\n              \"startTime\": 0.5,\n              \"duration\": 0.3,\n              \"chord\": \"C\"\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}\n```\n\n### API Endpoints\n\n| Endpoint | Method | Purpose |\n|----------|--------|---------|\n| `/upload` | POST | Upload audio file |\n| `/progress/:jobId` | GET | Analysis progress |\n| `/songmap/:jobId` | GET | Get Song Map JSON |\n| `/audio/:jobId/original` | GET | Get original audio |\n| `/audio/:jobId/stem/:type` | GET | Get stem (vocals, bass, drums, other) |\n\n---\n\n## 🎨 Design System\n\n### Color Palette\n\n#### Performance Mode (Stage)\n```css\n--bg-performance: rgb(10, 10, 12)      /* Near-black, minimal glare */\n--text-lyrics: rgb(240, 240, 245)      /* Cool white, max legibility */\n--chord-inactive: #FACC15              /* Warm amber (WCAG AAA) */\n--chord-active: #06b6d4                /* Performia cyan */\n--highlight-sung: rgba(6, 182, 212, 0.3)  /* Cyan glow */\n```\n\n#### UI Chrome (Controls)\n```css\n--bg-chrome: #111827                   /* Gray-900 */\n--bg-panel: #1f2937                    /* Gray-800 */\n--bg-input: #374151                    /* Gray-700 */\n--accent-primary: #06b6d4              /* Performia cyan */\n--accent-hover: #06d4f1                /* Lighter cyan */\n--accent-success: #22c55e              /* Green */\n--accent-warning: #eab308              /* Yellow */\n--accent-error: #ef4444                /* Red */\n```\n\n### Typography Scale\n\n```css\n/* Teleprompter (Performance) */\n--font-lyrics-default: 3.5rem   /* 56px - Stage optimized */\n--font-lyrics-min: 2.5rem       /* 40px */\n--font-lyrics-max: 6.0rem       /* 96px */\n--font-chord: 2.8rem            /* 45px - 80% ratio maintained */\n\n/* UI Chrome */\n--font-header-1: 2.5rem         /* Song title */\n--font-header-2: 1.875rem       /* Artist */\n--font-body: 1.125rem           /* Editable text */\n--font-control: 1rem            /* Buttons */\n--font-label: 0.875rem          /* Labels */\n--font-caption: 0.75rem         /* Metadata */\n```\n\n### Spacing System\n\n```css\n--space-xs:   4px\n--space-sm:   8px\n--space-md:   16px\n--space-lg:   24px\n--space-xl:   32px\n--space-2xl:  48px\n```\n\n### Border Radius\n\n```css\n--radius-sm:  4px\n--radius-md:  8px\n--radius-lg:  12px\n--radius-xl:  16px\n--radius-full: 9999px  /* Pill shape */\n```\n\n### Shadows\n\n```css\n--shadow-sm: 0 1px 2px rgba(0,0,0,0.05)\n--shadow-md: 0 4px 6px rgba(0,0,0,0.1)\n--shadow-lg: 0 10px 15px rgba(0,0,0,0.1)\n--shadow-xl: 0 20px 25px rgba(0,0,0,0.1)\n--shadow-cyan: 0 10px 15px rgba(6,182,212,0.2)\n```\n\n---\n\n## 🧩 Component Library\n\n### Core Components\n\n#### 1. TeleprompterView (Living Chart)\n**File:** `frontend/components/TeleprompterView.tsx`\n\n**Purpose:** Fullscreen lyrics with real-time syllable highlighting\n\n**Features:**\n- Real-time syllable highlighting\n- Auto-scroll (active line centered)\n- Chord display (names or diagrams)\n- Audio controls integration\n- Font size control (50%-150%)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│ [Audio Controls Bar]                │  ← 120-180px height\n├─────────────────────────────────────┤\n│                                     │\n│    Past lyrics (30% opacity)        │\n│                                     │\n│  ╔═══════════════════════════════╗ │\n│  ║   C              G            ║ │  ← Active line\n│  ║   Here comes the sun ◆ doo   ║ │  ← ◆ = current syllable\n│  ╚═══════════════════════════════╝ │\n│                                     │\n│    Future lyrics (100% opacity)     │\n│                                     │\n└─────────────────────────────────────┘\n```\n\n**Props:**\n```typescript\ninterface TeleprompterViewProps {\n  songMap: SongMap;\n  transpose: number;\n  capo: number;\n  chordDisplay: 'off' | 'names' | 'diagrams';\n  jobId?: string;\n}\n```\n\n---\n\n#### 2. AudioPlayer ✨ NEW\n**File:** `frontend/components/AudioPlayer.tsx`\n\n**Purpose:** Full-featured audio player with playback controls\n\n**Features:**\n- Play/pause button\n- Progress bar (draggable seek)\n- Volume control (slider + mute)\n- Time display (MM:SS / MM:SS)\n- Real-time sync with lyrics\n\n**UI Elements:**\n- **Progress Bar:** Cyan fill, gray background, draggable\n- **Play/Pause:** Cyan button, black text, icons ▶ ⏸\n- **Volume:** Slider (0.0-1.0), mute button 🔇 🔉 🔊\n- **Time:** Monospace font, white text\n\n**Container:** Gray-800 background, 16px padding, 8px radius\n\n**Props:**\n```typescript\ninterface AudioPlayerProps {\n  audioUrl: string;\n  onTimeUpdate: (currentTime: number) => void;\n  onDurationChange?: (duration: number) => void;\n  onPlayStateChange?: (isPlaying: boolean) => void;\n}\n```\n\n---\n\n#### 3. StemSelector ✨ NEW\n**File:** `frontend/components/StemSelector.tsx`\n\n**Purpose:** Toggle between audio stems (vocals, drums, bass, etc.)\n\n**Features:**\n- 5 stem types: Full Mix, Vocals, Bass, Drums, Other\n- Loading states (spinner icon)\n- Availability check (HEAD request)\n- Active state highlighting\n\n**Button States:**\n- **Selected:** Cyan background, black text, scale 105%, play icon ▶\n- **Unselected:** Gray-700 background, white text, hover gray-600\n- **Loading:** 50% opacity, spinning clock ⌛\n- **Unavailable:** 60% opacity, grayed out\n\n**Props:**\n```typescript\ninterface StemSelectorProps {\n  jobId: string;\n  baseUrl?: string;\n  onStemChange: (stemUrl: string, stemType: StemType) => void;\n}\n\ntype StemType = 'original' | 'vocals' | 'bass' | 'drums' | 'other';\n```\n\n---\n\n#### 4. Full Chart (Song Editor)\n**File:** `frontend/components/BlueprintView.tsx`\n\n**Purpose:** Document-style editor for song structure and chords\n\n**Features:**\n- Inline editing (click to edit)\n- Edit title, artist, lyrics, chords\n- Section headers (Verse, Chorus, etc.)\n- Chord autocomplete (planned Sprint 4)\n- Drag-to-reorder sections (planned Sprint 4)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│  Song Title (editable)              │\n│  Artist Name (editable)             │\n│  Key: C Major | BPM: 120            │\n├─────────────────────────────────────┤\n│  ┌─ [ Verse 1 ] ─────────────────┐ │\n│  │  C            G                │ │\n│  │  Here comes the sun           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  ┌─ [ Chorus ] ──────── [⋮] ─────┐ │  ← Drag handle\n│  │  ...                           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  [+ Add Section]                    │\n└─────────────────────────────────────┘\n```\n\n---\n\n#### 5. LibraryView\n**File:** `frontend/components/LibraryView.tsx`\n\n**Purpose:** Song search and library management\n\n**Features:**\n- Instant search (title, artist, lyrics, tags)\n- Filter by genre, key, BPM, difficulty\n- Sort by title, date added, last played\n- Quick actions: Play, Edit, Delete\n- Song cards with metadata\n\n**Search:** Fuzzy matching, autocomplete (planned Sprint 4)\n\n---\n\n#### 6. SettingsPanel\n**File:** `frontend/components/SettingsPanel.tsx`\n\n**Purpose:** Quick access to performance controls\n\n**Features:**\n- Chord display mode (Off, Names, Diagrams)\n- Font size slider (50%-150%)\n- Transpose (-12 to +12)\n- Capo (0-12 frets)\n- Settings presets (planned Sprint 4)\n- High contrast mode (planned Sprint 3)\n\n**Layout:** Slide-in from left, 384px width\n\n---\n\n#### 7. Header\n**File:** `frontend/components/Header.tsx`\n\n**Elements:**\n- Settings button (gear icon, cyan background)\n- Upload Song button\n- Demo button\n- Song title/artist display (center)\n\n---\n\n#### 8. ChordDiagram\n**File:** `frontend/components/ChordDiagram.tsx`\n\n**Purpose:** Guitar chord visualization\n\n**Elements:**\n- Fretboard grid\n- Finger positions\n- Chord name label\n\n---\n\n### Component Hierarchy\n\n```\nApp (State Manager)\n├── Header\n│   ├── Settings Button → Opens SettingsPanel\n│   ├── Upload Button → Triggers upload flow\n│   └── Song Title (center)\n│\n├── Main Content (View-Switched)\n│   ├── TeleprompterView (Performance Mode)\n│   │   ├── Audio Controls Bar ✨ NEW\n│   │   │   ├── StemSelector ✨ NEW\n│   │   │   └── AudioPlayer ✨ NEW\n│   │   └── Lyrics Display (Living Chart)\n│   │\n│   ├── Full Chart (Edit Mode)\n│   └── SongMapDemo\n│\n├── Footer\n│\n└── SettingsPanel (Modal)\n    └── LibraryView\n```\n\n---\n\n## 📋 Feature Status\n\n### ✅ Complete (Sprint 1-2)\n\n| Feature | Component | Status |\n|---------|-----------|--------|\n| **Teleprompter display** | TeleprompterView | ✅ Complete |\n| **Syllable highlighting** | TeleprompterView | ✅ Complete |\n| **Auto-scroll** | TeleprompterView | ✅ Complete |\n| **Chord display** | TeleprompterView | ✅ Complete |\n| **Audio playback** | AudioPlayer | ✅ Complete |\n| **Stem selection** | StemSelector | ✅ Complete |\n| **Progress bar** | AudioPlayer | ✅ Complete |\n| **Volume control** | AudioPlayer | ✅ Complete |\n| **Song Map generation** | Backend | ✅ Complete |\n| **Library management** | LibraryView | ✅ Complete |\n| **Settings panel** | SettingsPanel | ✅ Complete |\n| **Full Chart editor** | BlueprintView | ✅ Complete |\n\n### 🔨 In Progress\n\n| Feature | Target | Current | Sprint |\n|---------|--------|---------|--------|\n| **60fps rendering** | 60fps | 50fps | Sprint 3 |\n| **Settings speed** | <2s | ~4s | Sprint 3 |\n\n### 📋 Planned\n\n#### Sprint 3 (Oct 8-21): Performance & Accessibility\n- [ ] 60fps rendering optimization\n- [ ] Auto-center active line (50% viewport)\n- [ ] Keyboard navigation (8 shortcuts)\n- [ ] ARIA labels and semantic HTML\n- [ ] High contrast mode\n- [ ] Focus indicators\n- [ ] Reduced motion mode\n\n#### Sprint 4 (Oct 22 - Nov 4): Enhanced Editing + SongPrep Experimentation\n- [ ] Chord autocomplete popup\n- [ ] Drag-to-reorder sections\n- [ ] Real-time chord validation\n- [ ] Emergency font adjust (double-tap)\n- [ ] Library autocomplete search\n- [ ] Settings presets\n- [ ] **SongPrep Integration Research** (NEW)\n  - [ ] Clone SongPrep repository and set up environment\n  - [ ] Download 7B model weights from HuggingFace\n  - [ ] Test on 10 sample songs\n  - [ ] Benchmark inference speed and accuracy\n  - [ ] Compare section detection vs current heuristics\n  - [ ] Assess GPU requirements and resource impact\n  - [ ] Document findings and integration recommendations\n\n#### Sprint 5 (Nov 5-18): Polish & Testing + SongPrep Integration\n- [ ] Micro-interactions and animations\n- [ ] Loading states (skeleton screens)\n- [ ] User testing\n- [ ] Bug fixes and polish\n- [ ] **SongPrep Integration** (if Sprint 4 experiments successful)\n  - [ ] Create `backend/src/services/songprep/` module\n  - [ ] Implement parser for SongPrep output → Song Map format\n  - [ ] Update orchestrator for parallel processing\n  - [ ] Add confidence scoring to sections\n  - [ ] E2E testing: Audio → SongPrep → Living Chart\n  - [ ] Performance optimization (GPU, caching)\n\n### 🔮 Future (Post-MVP)\n\n- **Phase 2 (Q1 2026):** Setlist management, mobile support, SongPrep fine-tuning\n- **Phase 3 (Q2 2026):** Collaborative editing, cloud sync, genre-specific structure models\n- **Phase 4 (Q3 2026):** AI accompaniment (drums, bass, keys)\n- **Phase 5 (Q4 2026):** Voice commands, custom training datasets\n\n---\n\n## 🗺️ Roadmap\n\n### MVP Timeline\n\n| Sprint | Dates | Theme | Deliverables |\n|--------|-------|-------|--------------|\n| **1-2** | ✅ Complete | Backend + Audio | Analysis pipeline, audio playback, stems |\n| **3** | Oct 8-21 | Performance + A11y | 60fps, keyboard nav, ARIA, high contrast |\n| **4** | Oct 22-Nov 4 | Enhanced Editing | Chord autocomplete, drag sections, emergency font |\n| **5** | Nov 5-18 | Polish + Testing | Animations, loading states, user testing |\n| **MVP** | Nov 22 | Launch | Feature complete, accessible, bug-free |\n\n### Sprint 3 Breakdown (Oct 8-21)\n\n**Week 1: Performance**\n1. Optimize TeleprompterView rendering (virtual scrolling)\n2. Add syllable pulse animation\n3. Implement auto-centering (50% viewport)\n\n**Week 2: Accessibility**\n1. Keyboard navigation (8 shortcuts)\n2. ARIA labels on all elements\n3. High contrast mode\n4. Focus indicators\n\n**Acceptance Criteria:**\n- [ ] 60fps sustained for 10-min song\n- [ ] All elements keyboard accessible\n- [ ] WCAG AAA contrast ratios\n- [ ] Lighthouse accessibility score: 95+\n\n---\n\n## 🔧 Developer Guide\n\n### Project Structure\n\n```\nPerformia/\n├── frontend/                  # React frontend\n│   ├── components/           # React components\n│   ├── services/             # Library service, etc.\n│   ├── hooks/                # Custom hooks\n│   ├── data/                 # Mock data\n│   ├── types.ts              # TypeScript definitions\n│   └── index.css             # Global styles\n│\n├── backend/                   # Python backend\n│   ├── src/\n│   │   ├── main.py           # FastAPI server\n│   │   ├── services/         # Audio analysis\n│   │   └── schemas/          # JSON schemas\n│   └── requirements.txt\n│\n└── PERFORMIA_MASTER_DOCS.md  # This file\n```\n\n### Development Workflow\n\n1. **Start Backend:**\n   ```bash\n   cd backend\n   python src/main.py\n   ```\n\n2. **Start Frontend:**\n   ```bash\n   cd frontend\n   npm run dev\n   ```\n\n3. **Make Changes:**\n   - Hot reload enabled (Vite)\n   - Backend restarts on file change\n\n4. **Test:**\n   ```bash\n   # Frontend\n   npm test\n\n   # Backend\n   pytest\n   ```\n\n5. **Commit:**\n   ```bash\n   git add .\n   git commit -m \"feat: description\"\n   git push\n   ```\n\n### Key Files to Know\n\n| File | Purpose |\n|------|---------|\n| `frontend/App.tsx` | Main app component, state management |\n| `frontend/components/TeleprompterView.tsx` | Living Chart display |\n| `frontend/components/AudioPlayer.tsx` | Audio playback controls |\n| `frontend/types.ts` | TypeScript type definitions |\n| `backend/src/main.py` | FastAPI server, routes |\n| `backend/schemas/song_map.schema.json` | Song Map structure |\n\n### Adding a New Component\n\n1. Create file in `frontend/components/`\n2. Define TypeScript interface for props\n3. Implement component with accessibility (ARIA labels)\n4. Add to parent component\n5. Update this documentation\n\n### Debugging Tips\n\n**Frontend:**\n- React DevTools for component tree\n- Console.log sparingly (use breakpoints)\n- Check Network tab for API calls\n\n**Backend:**\n- FastAPI auto-docs: `http://localhost:8000/docs`\n- Check logs for errors\n- Use Python debugger (pdb)\n\n**Performance:**\n- Chrome DevTools Performance tab\n- Target: 60fps (16.67ms per frame)\n- Check for layout thrashing\n\n---\n\n## ♿ Accessibility\n\n### WCAG Compliance\n\n**Target:** WCAG 2.1 AA minimum, AAA for critical elements\n\n### Contrast Ratios\n\n| Element | Ratio | Standard |\n|---------|-------|----------|\n| Lyrics | 16:1 | AAA |\n| Chords | 7:1 | AAA |\n| UI Controls | 4.5:1 | AA |\n\n### Keyboard Navigation\n\n| Key | Action | Context |\n|-----|--------|---------|\n| **Space** | Play/pause | Teleprompter |\n| **←/→** | Prev/next section | Teleprompter |\n| **Cmd+,** | Open settings | Global |\n| **Cmd+L** | Open library | Global |\n| **Cmd+E** | Toggle edit mode | Global |\n| **Esc** | Close modal | Global |\n| **Tab** | Navigate controls | Settings |\n| **Cmd+↑/↓** | Font size ±10% | Teleprompter |\n\n### Screen Reader Support\n\n- Semantic HTML (`<header>`, `<main>`, `<nav>`)\n- ARIA labels on all interactive elements\n- ARIA live regions for dynamic content\n- Announce section changes and playback state\n\n### Visual Accessibility\n\n- **High contrast mode** (black-on-white toggle)\n- **Focus indicators** (2px cyan outline)\n- **Reduced motion** (disable animations)\n- **Minimum touch targets** (44x44px)\n\n### Testing Checklist\n\n- [ ] Tab through all interactive elements\n- [ ] Test with screen reader (VoiceOver/NVDA)\n- [ ] Check contrast with WCAG Color Contrast Checker\n- [ ] Test reduced motion preference\n- [ ] Verify focus indicators visible\n\n---\n\n## 📊 Success Metrics\n\n### Quantitative Targets\n\n| Metric | Target | Current | Status |\n|--------|--------|---------|--------|\n| **Time to first performance** | <30s | ✅ 25s | ✅ Met |\n| **Song search speed** | <5s | ✅ 3s | ✅ Met |\n| **Settings adjust speed** | <2s | 🔨 4s | 🔨 In progress |\n| **Frame rate** | 60fps | 🔨 50fps | 🔨 In progress |\n| **Audio latency** | <50ms | ✅ 35ms | ✅ Met |\n| **Analysis speed** | <30s/song | ✅ 22s | ✅ Met |\n| **Chord accuracy** | 90%+ | ✅ 92% | ✅ Met |\n| **Lyric accuracy** | 95%+ | ✅ 96% | ✅ Met |\n\n### Qualitative Targets\n\n- **Ease of use:** 4.5+ stars (out of 5)\n- **Feature discovery:** 80%+ without tutorial\n- **Visual clarity:** 95%+ \"easy to read\"\n- **Performance satisfaction:** 90%+ \"feels instant\"\n\n### Analytics to Track\n\n1. Time to first performance\n2. Songs uploaded per user\n3. Most used features\n4. Error rate\n5. Session duration\n6. Return rate (weekly active)\n\n---\n\n## 🔍 Frequently Asked Questions\n\n### General\n\n**Q: What audio formats are supported?**\nA: WAV, MP3, M4A, FLAC\n\n**Q: How long does song analysis take?**\nA: ~30 seconds per song (varies by length)\n\n**Q: Can I edit the auto-generated chords?**\nA: Yes, use Full Chart to edit chords inline\n\n**Q: Does it work offline?**\nA: Not yet (planned for Phase 3)\n\n### Technical\n\n**Q: Why 60fps target?**\nA: Smooth scrolling is critical for reading during performance. 60fps = 16.67ms per frame.\n\n**Q: Canvas vs DOM for rendering?**\nA: Currently DOM. Will optimize first, consider Canvas only if needed (accessibility trade-off).\n\n**Q: How does syllable sync work?**\nA: RequestAnimationFrame checks current audio time, finds matching syllable, updates highlight.\n\n**Q: Why Performia cyan?**\nA: High contrast with warm amber chords, signals \"now\", cool color stands out.\n\n---\n\n## 📝 Contribution Guidelines\n\n### Code Style\n\n- **TypeScript:** Strict mode, explicit types\n- **React:** Functional components, hooks\n- **CSS:** Tailwind utility classes, avoid inline styles\n- **Naming:** camelCase for variables, PascalCase for components\n\n### Commit Messages\n\n```\nfeat: Add emergency font adjust gesture\nfix: Resolve audio sync latency issue\ndocs: Update component API reference\nrefactor: Optimize TeleprompterView rendering\ntest: Add unit tests for chord validation\n```\n\n### Pull Requests\n\n1. Create feature branch: `git checkout -b feat/my-feature`\n2. Make changes and commit\n3. Push: `git push -u origin feat/my-feature`\n4. Open PR with description\n5. Request review\n6. Merge after approval\n\n---\n\n## 🐛 Known Issues & Limitations\n\n### Current Limitations\n\n1. **Desktop only** (mobile support in Phase 2)\n2. **Local storage** (no cloud sync yet)\n3. **No collaboration** (single user editing)\n4. **English lyrics only** (multi-language in future)\n\n### Known Bugs\n\n*None currently tracked for MVP*\n\n### Workarounds\n\n**Issue:** Font size changes lag\n**Workaround:** Use preset sizes instead of slider\n\n**Issue:** Large songs (>10min) slow down\n**Workaround:** Virtual scrolling coming in Sprint 3\n\n---\n\n## 📚 Additional Resources\n\n### External Links\n\n- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)\n- [React Performance](https://react.dev/learn/render-and-commit)\n- [Tailwind CSS Docs](https://tailwindcss.com/docs)\n- [FastAPI Docs](https://fastapi.tiangolo.com/)\n- **[SongPrep Repository](https://github.com/tencent-ailab/SongPrep)** - Song structure parsing\n- **[SongPrep Paper](https://arxiv.org/abs/2509.17404)** - Technical details\n\n### Internal Files\n\n- `backend/schemas/song_map.schema.json` - Song Map structure\n- `frontend/types.ts` - TypeScript definitions\n- `.claude/CLAUDE.md` - Agent SDK instructions\n- **`docs/research/SONGPREP_ANALYSIS.md`** - SongPrep integration research\n\n---\n\n## 📅 Document History\n\n| Version | Date | Changes |\n|---------|------|---------|\n| 3.0 | Oct 1, 2025 | Consolidated all docs into master file |\n| 2.0 | Oct 1, 2025 | Added AudioPlayer & StemSelector specs |\n| 1.0 | Sep 30, 2025 | Initial documentation structure |\n\n---\n\n## 🎯 Core Principle\n\n> **\"The best interface for performance is no interface at all.\"**\n\nEvery decision must answer:\n**\"Does this help the musician perform better, or does it distract?\"**\n\nIf it distracts → Cut it.\nIf it helps → Polish it until it's invisible.\n\n---\n\n**Maintained by:** Performia Development Team\n**Next Review:** End of Sprint 3 (Oct 21, 2025)\n**Questions?** Check the FAQ or open an issue\n"
+}

--- a/ui/server/viztrtr-workspaces/proj_1759617569660_4xniipw/product-spec.json
+++ b/ui/server/viztrtr-workspaces/proj_1759617569660_4xniipw/product-spec.json
@@ -1,0 +1,688 @@
+{
+  "projectId": "proj_1759617569660_4xniipw",
+  "version": 1,
+  "createdAt": "2025-10-04T22:42:00.751Z",
+  "lastUpdated": "2025-10-04T22:42:00.751Z",
+  "productVision": "Performia transforms live music performance by providing real-time audio analysis, AI-powered processing, and an intelligent Living Chart teleprompter that follows musicians in real-time, enabling them to focus entirely on their artistry without worrying about forgetting lyrics or chords.",
+  "targetUsers": [
+    "Live performers (vocalists, guitarists, bands) who perform 3-4 gigs per week and need large fonts readable from 6ft away with zero distractions",
+    "Rehearsal musicians learning new songs who need to edit chords and structure while practicing with isolated stems",
+    "Casual hobbyists practicing at home who need simple, intuitive interfaces to explore demo songs"
+  ],
+  "components": {
+    "TeleprompterView": {
+      "purpose": "Fullscreen lyrics display with real-time syllable highlighting that auto-scrolls and shows chords during live performance",
+      "userStories": [
+        "As a live performer, I need to see lyrics in large fonts (56px default) readable from 6ft away so I never lose my place on stage",
+        "As a musician, I need real-time syllable highlighting synchronized with audio playback so I know exactly where I am in the song",
+        "As a performer, I need chords displayed above lyrics with option to show diagrams so I can play along without memorizing",
+        "As a user, I need auto-scrolling that keeps the active line centered so I never have to manually scroll during performance"
+      ],
+      "designPriorities": [
+        "Maximum legibility",
+        "Zero-latency feel",
+        "Minimal visual distractions",
+        "Performance-first interface"
+      ],
+      "focusAreas": [
+        "Font size control (2.5rem-6.0rem range)",
+        "Syllable highlight animation with cyan glow",
+        "Auto-centering active line at 50% viewport",
+        "Past lyrics 30% opacity, future 100% opacity",
+        "Chord display modes: off, names, diagrams",
+        "60fps rendering for smooth scrolling",
+        "Keyboard shortcuts for section navigation"
+      ],
+      "avoidAreas": [
+        "Complex UI chrome during performance mode",
+        "Distracting animations or transitions",
+        "Small touch targets",
+        "Low contrast color combinations"
+      ],
+      "acceptanceCriteria": [
+        "Sustain 60fps rendering for 10-minute songs",
+        "Lyrics WCAG AAA contrast ratio (16:1)",
+        "Active line centered within 50ms of scroll event",
+        "Font size adjustable 50%-150% without layout shift",
+        "Syllable highlight synchronized within 50ms of audio",
+        "Keyboard navigation works for all sections",
+        "Readable from 6ft distance at default settings"
+      ],
+      "status": "complete"
+    },
+    "AudioPlayer": {
+      "purpose": "Full-featured audio playback controls with play/pause, seek, volume, and time display synchronized with lyrics",
+      "userStories": [
+        "As a performer, I need play/pause controls easily accessible so I can start and stop playback quickly",
+        "As a musician, I need to seek to specific song sections by dragging the progress bar so I can practice specific parts",
+        "As a user, I need volume controls with mute option so I can adjust audio levels without leaving the interface",
+        "As a rehearsing musician, I need to see current time and total duration so I know where I am in the song"
+      ],
+      "designPriorities": [
+        "Touch-friendly controls",
+        "Visual feedback on interaction",
+        "Real-time sync with lyrics",
+        "Minimal latency"
+      ],
+      "focusAreas": [
+        "Large play/pause button with cyan accent",
+        "Draggable progress bar with cyan fill indicator",
+        "Volume slider (0.0-1.0) with mute toggle",
+        "Monospace time display (MM:SS format)",
+        "Audio latency under 50ms",
+        "Smooth progress bar updates",
+        "Container: gray-800 background, 16px padding"
+      ],
+      "avoidAreas": [
+        "Complex waveform visualizations during performance",
+        "Small slider handles",
+        "Unclear playback state indicators"
+      ],
+      "acceptanceCriteria": [
+        "Audio latency below 50ms",
+        "Progress bar updates at 30fps minimum",
+        "Volume slider responsive within 100ms",
+        "Play/pause state visible from 6ft away",
+        "Time display uses monospace font",
+        "Touch targets minimum 44x44px",
+        "Seek operation completes within 200ms"
+      ],
+      "status": "complete"
+    },
+    "StemSelector": {
+      "purpose": "Toggle between audio stems (vocals, drums, bass, other) for practice and rehearsal with loading states and availability checks",
+      "userStories": [
+        "As a rehearsing musician, I need to isolate vocals so I can practice singing without interference",
+        "As a guitarist, I need to mute the guitar stem so I can play along with the band mix",
+        "As a user, I need to see loading states when stems are being fetched so I know the system is working",
+        "As a musician, I need to switch between stems quickly without interrupting playback flow"
+      ],
+      "designPriorities": [
+        "Clear visual distinction between active/inactive stems",
+        "Loading state feedback",
+        "Fast stem switching",
+        "Availability indication"
+      ],
+      "focusAreas": [
+        "5 stem buttons: Full Mix, Vocals, Bass, Drums, Other",
+        "Selected state: cyan background, black text, scale 105%, play icon",
+        "Unselected state: gray-700 background, white text",
+        "Loading state: 50% opacity, spinning clock icon",
+        "Unavailable state: 60% opacity, grayed out",
+        "HEAD request for availability check",
+        "Maintain playback position when switching"
+      ],
+      "avoidAreas": [
+        "Complex stem mixing UI during performance",
+        "Unclear loading states",
+        "Accidental stem switches"
+      ],
+      "acceptanceCriteria": [
+        "Stem switch completes within 500ms",
+        "Loading state appears within 100ms",
+        "Selected stem visually distinct at 6ft distance",
+        "Playback position preserved within 50ms when switching",
+        "Availability check completes before rendering buttons",
+        "Touch targets minimum 44x44px",
+        "Keyboard accessible with Tab navigation"
+      ],
+      "status": "complete"
+    },
+    "FullChart": {
+      "purpose": "Document-style editor for song structure, lyrics, and chords with inline editing capabilities",
+      "userStories": [
+        "As a musician, I need to edit song titles and artist names so I can correct auto-generated metadata",
+        "As a user, I need to click on lyrics or chords to edit them inline so I can fix errors quickly",
+        "As a rehearsing musician, I need to see song sections clearly organized (Verse, Chorus) so I understand song structure",
+        "As an advanced user, I need to add new sections and reorder them so I can customize song arrangements"
+      ],
+      "designPriorities": [
+        "Intuitive inline editing",
+        "Clear section hierarchy",
+        "Minimal mode switching",
+        "Preserve formatting on save"
+      ],
+      "focusAreas": [
+        "Editable title, artist, key, BPM fields",
+        "Section headers with collapse/expand",
+        "Inline chord and lyric editing",
+        "Click to edit, blur to save pattern",
+        "Chord autocomplete (Sprint 4 planned)",
+        "Drag-to-reorder sections (Sprint 4 planned)",
+        "Visual feedback on hover/focus",
+        "Add section button at bottom"
+      ],
+      "avoidAreas": [
+        "Modal dialogs for simple edits",
+        "Complex formatting toolbars",
+        "Unclear edit mode indicators"
+      ],
+      "acceptanceCriteria": [
+        "Edit mode activates within 100ms of click",
+        "Changes save within 200ms of blur event",
+        "Chord validation provides feedback within 300ms",
+        "Section reordering completes without flicker",
+        "Keyboard shortcuts work for common edits",
+        "Undo/redo functionality available",
+        "WCAG AA contrast for edit fields"
+      ],
+      "status": "complete"
+    },
+    "LibraryView": {
+      "purpose": "Song search and library management interface with filtering, sorting, and quick actions",
+      "userStories": [
+        "As a performer, I need to search songs by title or artist instantly so I can find songs quickly before a gig",
+        "As a user, I need to filter songs by genre, key, or BPM so I can find songs matching my setlist requirements",
+        "As a musician, I need quick actions (Play, Edit, Delete) on song cards so I can manage my library efficiently",
+        "As a user, I need to sort songs by date added or last played so I can organize my library"
+      ],
+      "designPriorities": [
+        "Instant search results",
+        "Clear visual hierarchy",
+        "Efficient space usage",
+        "Quick access to actions"
+      ],
+      "focusAreas": [
+        "Real-time fuzzy search on title, artist, lyrics, tags",
+        "Filter dropdowns: genre, key, BPM, difficulty",
+        "Sort options: title, date added, last played",
+        "Song cards with metadata (duration, key, last played)",
+        "Quick action buttons on card hover",
+        "Autocomplete suggestions (Sprint 4 planned)",
+        "Grid or list view toggle",
+        "Empty state with upload prompt"
+      ],
+      "avoidAreas": [
+        "Slow search that requires submit button",
+        "Hidden actions requiring multiple clicks",
+        "Overcrowded card design"
+      ],
+      "acceptanceCriteria": [
+        "Search results appear within 5 seconds",
+        "Fuzzy matching finds songs with typos",
+        "Filter application completes within 1 second",
+        "Song cards show key metadata at a glance",
+        "Quick actions accessible with single click",
+        "Keyboard navigation through search results",
+        "WCAG AA contrast for all text elements"
+      ],
+      "status": "complete"
+    },
+    "SettingsPanel": {
+      "purpose": "Quick access panel for performance controls including chord display, font size, transpose, and capo",
+      "userStories": [
+        "As a performer, I need to toggle chord display modes (off, names, diagrams) so I can choose what I see on stage",
+        "As a user, I need a font size slider so I can adjust readability based on my distance from the screen",
+        "As a musician, I need to transpose songs up or down so I can match my vocal range",
+        "As a guitarist, I need to set a capo position so chords display correctly for my playing style"
+      ],
+      "designPriorities": [
+        "Fast adjustments",
+        "Real-time preview",
+        "Persist preferences",
+        "Minimal cognitive load"
+      ],
+      "focusAreas": [
+        "Chord display toggle: off, names, diagrams",
+        "Font size slider: 50%-150% with live preview",
+        "Transpose selector: -12 to +12 semitones",
+        "Capo selector: 0-12 frets",
+        "Settings presets (Sprint 4 planned)",
+        "High contrast mode toggle (Sprint 3 planned)",
+        "Slide-in panel from left, 384px width",
+        "Close button and Esc key support"
+      ],
+      "avoidAreas": [
+        "Settings that require page reload",
+        "Unclear impact of adjustments",
+        "Too many nested menus"
+      ],
+      "acceptanceCriteria": [
+        "Settings changes apply within 2 seconds",
+        "Font size preview updates in real-time",
+        "Transpose updates all chords correctly",
+        "Capo calculation accurate for all chord types",
+        "Settings persist across sessions",
+        "Panel opens/closes within 300ms",
+        "Keyboard accessible (Tab, Esc)"
+      ],
+      "status": "complete"
+    },
+    "Header": {
+      "purpose": "Top navigation bar with settings, upload, demo buttons, and centered song title display",
+      "userStories": [
+        "As a user, I need a settings button easily accessible so I can adjust preferences without leaving the performance view",
+        "As a musician, I need an upload button visible so I can add new songs to my library anytime",
+        "As a new user, I need a demo button so I can explore Performia features without uploading my own songs",
+        "As a performer, I need to see the current song title and artist centered so I can confirm what I am performing"
+      ],
+      "designPriorities": [
+        "Always visible",
+        "Minimal height",
+        "Clear button hierarchy",
+        "Consistent branding"
+      ],
+      "focusAreas": [
+        "Settings button: gear icon, cyan background",
+        "Upload button: prominent, clear call-to-action",
+        "Demo button: secondary styling",
+        "Song title and artist: centered, truncate if long",
+        "Fixed position at top",
+        "Height: 64px",
+        "Responsive on smaller screens"
+      ],
+      "avoidAreas": [
+        "Obscuring performance view content",
+        "Too many competing buttons",
+        "Unclear button purposes"
+      ],
+      "acceptanceCriteria": [
+        "Header height does not exceed 80px",
+        "Settings button opens panel within 300ms",
+        "Upload button triggers file dialog immediately",
+        "Song title truncates gracefully on narrow screens",
+        "All buttons have ARIA labels",
+        "Touch targets minimum 44x44px",
+        "Header remains fixed during scroll"
+      ],
+      "status": "complete"
+    },
+    "ChordDiagram": {
+      "purpose": "Visual guitar chord fretboard display showing finger positions and chord names",
+      "userStories": [
+        "As a guitarist, I need to see chord diagrams so I know exact finger positions without memorizing",
+        "As a beginner, I need clear fretboard visualization so I can learn chords visually",
+        "As a performer, I need chord diagrams large enough to read from a distance during practice"
+      ],
+      "designPriorities": [
+        "Clear finger positions",
+        "Standard chord notation",
+        "Scalable size",
+        "High contrast"
+      ],
+      "focusAreas": [
+        "Fretboard grid with 6 strings and 4-5 frets",
+        "Finger position dots with numbers",
+        "Chord name label at top",
+        "Open/muted string indicators (O, X)",
+        "Scale with parent font size",
+        "Black on white or white on black modes",
+        "Standard guitar chord library"
+      ],
+      "avoidAreas": [
+        "Overly decorative fretboard designs",
+        "Unclear finger numbering",
+        "Non-standard chord notation"
+      ],
+      "acceptanceCriteria": [
+        "Chord diagrams readable from 4ft distance",
+        "All common chords supported (major, minor, 7th, sus, etc.)",
+        "Diagrams scale proportionally with font size",
+        "WCAG AA contrast ratio maintained",
+        "Finger positions clearly numbered 1-4",
+        "Open/muted strings indicated at top"
+      ],
+      "status": "complete"
+    },
+    "UploadFlow": {
+      "purpose": "File upload interface with drag-and-drop, progress tracking, and error handling",
+      "userStories": [
+        "As a user, I need to drag and drop audio files so I can upload songs quickly without file dialogs",
+        "As a musician, I need to see upload and analysis progress so I know how long to wait",
+        "As a user, I need clear error messages if upload fails so I can troubleshoot issues",
+        "As a performer, I need to cancel uploads if I change my mind so I do not waste time"
+      ],
+      "designPriorities": [
+        "Intuitive upload UX",
+        "Clear progress feedback",
+        "Error recovery",
+        "Multiple file support"
+      ],
+      "focusAreas": [
+        "Drag-and-drop zone with visual feedback",
+        "File format validation (WAV, MP3, M4A, FLAC)",
+        "Upload progress bar (0-100%)",
+        "Analysis progress bar with stages (transcription, chords, stems)",
+        "Cancel button during upload/analysis",
+        "Error messages with retry option",
+        "Success state redirects to song view",
+        "File size limit (100MB recommended)"
+      ],
+      "avoidAreas": [
+        "Unclear upload states",
+        "No feedback during long operations",
+        "Confusing error messages"
+      ],
+      "acceptanceCriteria": [
+        "Upload completes within expected time (<30s for 5MB file)",
+        "Progress updates at least every 500ms",
+        "Invalid file types rejected with clear message",
+        "Cancel button stops upload within 1 second",
+        "Analysis completes within 30 seconds per song",
+        "Success state shows song title and Play button",
+        "WCAG AA contrast for progress indicators"
+      ],
+      "status": "active"
+    },
+    "AudioControlsBar": {
+      "purpose": "Consolidated audio controls bar containing StemSelector and AudioPlayer for performance mode",
+      "userStories": [
+        "As a performer, I need all audio controls in one bar so I can manage playback without hunting for buttons",
+        "As a user, I need the controls bar always visible so I can pause or adjust volume anytime",
+        "As a rehearsing musician, I need quick access to stems and playback controls in the same place"
+      ],
+      "designPriorities": [
+        "Consolidated controls",
+        "Always accessible",
+        "Minimal height",
+        "Visual consistency"
+      ],
+      "focusAreas": [
+        "Fixed position below header",
+        "Height: 120-180px",
+        "Contains StemSelector and AudioPlayer",
+        "Gray-800 background",
+        "Responsive layout on smaller screens",
+        "Smooth show/hide animation",
+        "Does not obscure lyrics"
+      ],
+      "avoidAreas": [
+        "Excessive height that reduces lyrics space",
+        "Controls that are hard to reach",
+        "Inconsistent styling with other components"
+      ],
+      "acceptanceCriteria": [
+        "Controls bar height between 120-180px",
+        "All controls accessible without scrolling",
+        "Background color matches design system",
+        "Show/hide animation completes within 300ms",
+        "Touch targets minimum 44x44px",
+        "Keyboard accessible (Tab navigation)",
+        "Does not flicker during state changes"
+      ],
+      "status": "active"
+    },
+    "EmergencyFontAdjust": {
+      "purpose": "Double-tap gesture to quickly increase or decrease font size during performance without opening settings",
+      "userStories": [
+        "As a performer on stage, I need to quickly increase font size if I cannot read lyrics without opening menus",
+        "As a musician, I need a panic button for font adjustments so I can fix readability issues mid-performance"
+      ],
+      "designPriorities": [
+        "Zero-friction interaction",
+        "Immediate feedback",
+        "No UI chrome",
+        "Reversible action"
+      ],
+      "focusAreas": [
+        "Double-tap gesture detection",
+        "Font size increment: +10% per double-tap",
+        "Visual feedback: brief scale animation",
+        "Keyboard shortcut: Cmd+Up/Down",
+        "Toast notification with new size",
+        "Maximum 150% and minimum 50% limits",
+        "Persist adjustment to settings"
+      ],
+      "avoidAreas": [
+        "Complex gesture recognition",
+        "Delayed feedback",
+        "Unclear adjustment amount"
+      ],
+      "acceptanceCriteria": [
+        "Double-tap detection within 300ms",
+        "Font size change applies within 100ms",
+        "Visual feedback completes within 200ms",
+        "Keyboard shortcut works immediately",
+        "Toast dismisses after 2 seconds",
+        "Does not interfere with scrolling gestures",
+        "Works in fullscreen mode"
+      ],
+      "status": "planned-sprint-4"
+    },
+    "KeyboardShortcuts": {
+      "purpose": "Global keyboard shortcuts for common actions to enable hands-free operation and accessibility",
+      "userStories": [
+        "As a power user, I need keyboard shortcuts so I can navigate without touching the mouse",
+        "As a performer, I need Space to play/pause so I can control playback with one hand",
+        "As a user with mobility challenges, I need full keyboard navigation so I can use Performia without a mouse"
+      ],
+      "designPriorities": [
+        "Standard shortcuts",
+        "Discoverable",
+        "No conflicts",
+        "Accessible focus"
+      ],
+      "focusAreas": [
+        "Space: Play/pause",
+        "Left/Right arrows: Previous/next section",
+        "Cmd+,: Open settings",
+        "Cmd+L: Open library",
+        "Cmd+E: Toggle edit mode",
+        "Esc: Close modal",
+        "Tab: Navigate controls",
+        "Cmd+Up/Down: Font size +/-10%",
+        "Shortcuts overlay (? key)",
+        "Focus indicators (2px cyan outline)"
+      ],
+      "avoidAreas": [
+        "Non-standard shortcuts",
+        "Conflicting browser shortcuts",
+        "Invisible focus indicators"
+      ],
+      "acceptanceCriteria": [
+        "All shortcuts listed in documentation",
+        "No conflicts with browser defaults",
+        "Shortcuts work in all views",
+        "Focus indicators visible on all elements",
+        "Tab order follows visual hierarchy",
+        "Shortcuts overlay accessible via ? key",
+        "Screen reader announces shortcut actions"
+      ],
+      "status": "planned-sprint-3"
+    },
+    "HighContrastMode": {
+      "purpose": "Toggle high contrast mode for improved visibility in bright environments or for users with visual impairments",
+      "userStories": [
+        "As a performer in bright stage lighting, I need high contrast mode so I can read lyrics clearly",
+        "As a user with low vision, I need maximum contrast so text is legible without straining"
+      ],
+      "designPriorities": [
+        "Maximum contrast",
+        "Preserve readability",
+        "Quick toggle",
+        "Persist preference"
+      ],
+      "focusAreas": [
+        "Black on white or white on black toggle",
+        "WCAG AAA contrast ratios (21:1)",
+        "Settings panel toggle switch",
+        "Maintain chord color distinction",
+        "Apply to all views",
+        "Preserve focus indicators",
+        "Store preference in localStorage"
+      ],
+      "avoidAreas": [
+        "Mid-gray backgrounds",
+        "Low contrast color schemes",
+        "Inconsistent application across views"
+      ],
+      "acceptanceCriteria": [
+        "Contrast ratios meet WCAG AAA (21:1)",
+        "Toggle applies within 500ms",
+        "All text remains legible",
+        "Chord colors remain distinct",
+        "Preference persists across sessions",
+        "Works in all views (teleprompter, editor, library)",
+        "No flicker during mode switch"
+      ],
+      "status": "planned-sprint-3"
+    },
+    "ReducedMotionMode": {
+      "purpose": "Respect prefers-reduced-motion system preference to disable animations for users sensitive to motion",
+      "userStories": [
+        "As a user with vestibular disorders, I need reduced motion so animations do not cause discomfort",
+        "As a user, I need the system to respect my OS accessibility settings automatically"
+      ],
+      "designPriorities": [
+        "Respect user preferences",
+        "Maintain functionality",
+        "No motion-dependent features",
+        "Graceful degradation"
+      ],
+      "focusAreas": [
+        "Detect prefers-reduced-motion CSS media query",
+        "Disable scroll animations",
+        "Disable transition effects",
+        "Remove parallax effects",
+        "Maintain instant state changes",
+        "Keep essential feedback (color changes)",
+        "Manual toggle in settings (Sprint 3)"
+      ],
+      "avoidAreas": [
+        "Features that require animation to function",
+        "Ignoring system preferences",
+        "Abrupt visual changes"
+      ],
+      "acceptanceCriteria": [
+        "prefers-reduced-motion detected on load",
+        "All animations disabled when preference set",
+        "State changes remain clear without animation",
+        "Functionality unchanged in reduced motion mode",
+        "Manual toggle available in settings",
+        "No layout shifts when disabling animations",
+        "Focus changes remain visible"
+      ],
+      "status": "planned-sprint-3"
+    },
+    "SongPrepIntegration": {
+      "purpose": "Integrate SongPrep AI model for improved song structure parsing and section detection",
+      "userStories": [
+        "As a developer, I need to evaluate SongPrep accuracy so I can decide if it improves section detection",
+        "As a user, I need more accurate section labels (Verse, Chorus, Bridge) so I can navigate songs intuitively"
+      ],
+      "designPriorities": [
+        "Improved accuracy",
+        "Minimal performance impact",
+        "Fallback to current method",
+        "Transparent integration"
+      ],
+      "focusAreas": [
+        "Clone SongPrep repository (Sprint 4)",
+        "Download 7B model weights from HuggingFace",
+        "Test on 10 sample songs for accuracy",
+        "Benchmark inference speed and GPU requirements",
+        "Compare section detection vs current heuristics",
+        "Implement parser for SongPrep output to Song Map format (Sprint 5)",
+        "Add confidence scoring to sections",
+        "Create fallback to current method if SongPrep fails"
+      ],
+      "avoidAreas": [
+        "Blocking analysis pipeline on SongPrep",
+        "Requiring GPU for all users",
+        "Breaking existing Song Map format"
+      ],
+      "acceptanceCriteria": [
+        "SongPrep section detection accuracy >85%",
+        "Inference time <10 seconds per song",
+        "GPU memory usage <4GB",
+        "Fallback to heuristics if SongPrep unavailable",
+        "Song Map format unchanged",
+        "Confidence scores included in output",
+        "E2E test: Audio to SongPrep to Living Chart"
+      ],
+      "status": "planned-sprint-4-5"
+    },
+    "LoadingStates": {
+      "purpose": "Skeleton screens and loading indicators to provide feedback during async operations",
+      "userStories": [
+        "As a user, I need loading indicators so I know the system is working and not frozen",
+        "As a musician, I need skeleton screens during song load so I see the layout structure before content appears"
+      ],
+      "designPriorities": [
+        "Immediate feedback",
+        "Perceived performance",
+        "Reduce anxiety",
+        "Consistent patterns"
+      ],
+      "focusAreas": [
+        "Skeleton screens for song cards",
+        "Spinner for audio analysis progress",
+        "Progress bars for upload and analysis stages",
+        "Loading text with stage names",
+        "Estimated time remaining",
+        "Shimmer animation on skeleton screens",
+        "Error states with retry button"
+      ],
+      "avoidAreas": [
+        "Generic spinners without context",
+        "Blocking the entire UI",
+        "Unclear what is loading"
+      ],
+      "acceptanceCriteria": [
+        "Loading indicator appears within 100ms",
+        "Skeleton screens match final layout",
+        "Progress bars update at least every 500ms",
+        "Estimated time within 20% accuracy",
+        "Error states provide clear next steps",
+        "Loading states accessible to screen readers",
+        "Animations respect prefers-reduced-motion"
+      ],
+      "status": "planned-sprint-5"
+    }
+  },
+  "globalConstraints": {
+    "accessibility": [
+      "WCAG 2.1 AA minimum, AAA for critical elements (lyrics, chords)",
+      "Keyboard navigation for all interactive elements",
+      "ARIA labels on all buttons, inputs, and dynamic content",
+      "Semantic HTML (header, main, nav, section)",
+      "ARIA live regions for dynamic content updates",
+      "Focus indicators visible (2px cyan outline)",
+      "Minimum touch targets 44x44px",
+      "Screen reader support (VoiceOver, NVDA)",
+      "High contrast mode toggle",
+      "Reduced motion mode support",
+      "Minimum font size 16px for UI, 40px for performance view"
+    ],
+    "performance": [
+      "60fps sustained rendering for 10-minute songs",
+      "Audio latency below 50ms",
+      "Syllable highlight sync within 50ms",
+      "Settings changes apply within 2 seconds",
+      "Song search results within 5 seconds",
+      "Upload and analysis complete within 30 seconds per song",
+      "Perceived interaction time under 100ms",
+      "Virtual scrolling for large song lists",
+      "Optimize re-renders with React.memo and useCallback",
+      "Lazy load non-critical components"
+    ],
+    "browser": [
+      "Chrome 90+",
+      "Safari 14+",
+      "Firefox 88+",
+      "Edge 90+",
+      "Desktop only (mobile support in Phase 2)",
+      "Minimum screen resolution 1280x720",
+      "Audio API support required",
+      "LocalStorage for preferences",
+      "Fullscreen API support"
+    ],
+    "design": [
+      "Performia cyan (#06b6d4) as primary accent",
+      "Near-black background (#0A0A0C) for performance mode",
+      "Gray-800 to Gray-900 for UI chrome",
+      "Cool white text (#F0F0F5) for maximum legibility",
+      "Warm amber (#FACC15) for inactive chords",
+      "Cyan glow for active elements",
+      "Tailwind CSS 4 utility classes",
+      "Consistent spacing system (4px base unit)",
+      "Border radius: 4px-16px scale",
+      "Shadows with subtle cyan tint for active states",
+      "Typography scale: 0.75rem-6rem",
+      "Performance-first principle: UI disappears during performance",
+      "Progressive disclosure: complexity hidden until needed",
+      "Zero-latency feel for all interactions"
+    ]
+  },
+  "originalPRD": "# 🎵 Performia - Complete Documentation\n\n**Version:** 3.0\n**Last Updated:** October 1, 2025\n**Status:** Living Document\n\n---\n\n## 📖 Table of Contents\n\n### Quick Navigation\n- [🎯 Product Overview](#-product-overview)\n- [🚀 Quick Start](#-quick-start)\n- [🏗️ Architecture](#️-architecture)\n- [🎨 Design System](#-design-system)\n- [🧩 Component Library](#-component-library)\n- [📋 Feature Status](#-feature-status)\n- [🗺️ Roadmap](#️-roadmap)\n- [🔧 Developer Guide](#-developer-guide)\n- [♿ Accessibility](#-accessibility)\n- [📊 Success Metrics](#-success-metrics)\n\n---\n\n## 🎯 Product Overview\n\n### What is Performia?\n\n**Performia** is a revolutionary music performance system that transforms how musicians perform live. By combining real-time audio analysis, AI-powered audio processing, and an intelligent \"Living Chart\" teleprompter, Performia enables musicians to focus on their artistry.\n\n**Core Value Proposition:**\n*\"Never forget lyrics or chords again. Performia follows YOU in real-time.\"*\n\n### Target Users\n\n1. **Live Performers** (Primary)\n   - Vocalists, guitarists, bands\n   - Perform 3-4 gigs per week\n   - Need large fonts readable from 6ft away\n   - Zero distractions during performance\n\n2. **Rehearsal Musicians** (Secondary)\n   - Learning new songs\n   - Need to edit chords and structure\n   - Practice with isolated stems\n\n3. **Casual Hobbyists** (Tertiary)\n   - Home practice\n   - Need simple, intuitive interface\n   - Explore demo songs\n\n### Design Philosophy\n\n> **\"The best interface for performance is no interface at all.\"**\n\n**Core Principles:**\n1. **Performance-First**: UI disappears during performance\n2. **Zero-Latency Feel**: <100ms perceived interaction time\n3. **Musician Mental Model**: Sections, keys, chords\n4. **Progressive Disclosure**: Complexity hidden until needed\n5. **Accessibility by Default**: Works for all musicians\n\n---\n\n## 🚀 Quick Start\n\n### Running Performia\n\n#### Backend (Python + C++)\n```bash\ncd backend\npython -m venv venv\nsource venv/bin/activate  # On Windows: venv\\Scripts\\activate\npip install -r requirements.txt\npython src/main.py\n```\n\nBackend runs on: `http://localhost:8000`\n\n#### Frontend (React + Vite)\n```bash\ncd frontend\nnpm install\nnpm run dev\n```\n\nFrontend runs on: `http://localhost:5001`\n\n### First-Time User Flow\n\n1. **Open Performia** → Demo song \"Yesterday\" loads automatically\n2. **Click Settings** (gear icon) → Adjust font size, transpose\n3. **Click Play** → Watch syllables highlight in real-time\n4. **Upload Song** → Drop audio file, wait ~30s for analysis\n5. **Perform** → Fullscreen lyrics with chords, zero distractions\n\n---\n\n## 🏗️ Architecture\n\n### Tech Stack\n\n**Frontend:**\n- React 19 + TypeScript 5\n- Vite 6 (build tool)\n- Tailwind CSS 4 (styling)\n- React hooks (state management)\n\n**Backend:**\n- Python 3.11 + FastAPI\n- JUCE (C++ audio engine)\n- Librosa (audio analysis)\n- Demucs (stem separation)\n- Whisper (speech recognition / ASR)\n- **SongPrep** (planned - song structure parsing)\n\n### Data Flow\n\n```\n1. Upload Audio → Backend\n2. Analysis Pipeline → Song Map JSON\n3. Frontend → Display Living Chart\n4. Audio Playback → Syllable Sync\n```\n\n### Song Map Schema\n\n```json\n{\n  \"title\": \"Song Title\",\n  \"artist\": \"Artist Name\",\n  \"key\": \"C Major\",\n  \"bpm\": 120,\n  \"sections\": [\n    {\n      \"name\": \"Verse 1\",\n      \"lines\": [\n        {\n          \"syllables\": [\n            {\n              \"text\": \"Hello\",\n              \"startTime\": 0.5,\n              \"duration\": 0.3,\n              \"chord\": \"C\"\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}\n```\n\n### API Endpoints\n\n| Endpoint | Method | Purpose |\n|----------|--------|---------|\n| `/upload` | POST | Upload audio file |\n| `/progress/:jobId` | GET | Analysis progress |\n| `/songmap/:jobId` | GET | Get Song Map JSON |\n| `/audio/:jobId/original` | GET | Get original audio |\n| `/audio/:jobId/stem/:type` | GET | Get stem (vocals, bass, drums, other) |\n\n---\n\n## 🎨 Design System\n\n### Color Palette\n\n#### Performance Mode (Stage)\n```css\n--bg-performance: rgb(10, 10, 12)      /* Near-black, minimal glare */\n--text-lyrics: rgb(240, 240, 245)      /* Cool white, max legibility */\n--chord-inactive: #FACC15              /* Warm amber (WCAG AAA) */\n--chord-active: #06b6d4                /* Performia cyan */\n--highlight-sung: rgba(6, 182, 212, 0.3)  /* Cyan glow */\n```\n\n#### UI Chrome (Controls)\n```css\n--bg-chrome: #111827                   /* Gray-900 */\n--bg-panel: #1f2937                    /* Gray-800 */\n--bg-input: #374151                    /* Gray-700 */\n--accent-primary: #06b6d4              /* Performia cyan */\n--accent-hover: #06d4f1                /* Lighter cyan */\n--accent-success: #22c55e              /* Green */\n--accent-warning: #eab308              /* Yellow */\n--accent-error: #ef4444                /* Red */\n```\n\n### Typography Scale\n\n```css\n/* Teleprompter (Performance) */\n--font-lyrics-default: 3.5rem   /* 56px - Stage optimized */\n--font-lyrics-min: 2.5rem       /* 40px */\n--font-lyrics-max: 6.0rem       /* 96px */\n--font-chord: 2.8rem            /* 45px - 80% ratio maintained */\n\n/* UI Chrome */\n--font-header-1: 2.5rem         /* Song title */\n--font-header-2: 1.875rem       /* Artist */\n--font-body: 1.125rem           /* Editable text */\n--font-control: 1rem            /* Buttons */\n--font-label: 0.875rem          /* Labels */\n--font-caption: 0.75rem         /* Metadata */\n```\n\n### Spacing System\n\n```css\n--space-xs:   4px\n--space-sm:   8px\n--space-md:   16px\n--space-lg:   24px\n--space-xl:   32px\n--space-2xl:  48px\n```\n\n### Border Radius\n\n```css\n--radius-sm:  4px\n--radius-md:  8px\n--radius-lg:  12px\n--radius-xl:  16px\n--radius-full: 9999px  /* Pill shape */\n```\n\n### Shadows\n\n```css\n--shadow-sm: 0 1px 2px rgba(0,0,0,0.05)\n--shadow-md: 0 4px 6px rgba(0,0,0,0.1)\n--shadow-lg: 0 10px 15px rgba(0,0,0,0.1)\n--shadow-xl: 0 20px 25px rgba(0,0,0,0.1)\n--shadow-cyan: 0 10px 15px rgba(6,182,212,0.2)\n```\n\n---\n\n## 🧩 Component Library\n\n### Core Components\n\n#### 1. TeleprompterView (Living Chart)\n**File:** `frontend/components/TeleprompterView.tsx`\n\n**Purpose:** Fullscreen lyrics with real-time syllable highlighting\n\n**Features:**\n- Real-time syllable highlighting\n- Auto-scroll (active line centered)\n- Chord display (names or diagrams)\n- Audio controls integration\n- Font size control (50%-150%)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│ [Audio Controls Bar]                │  ← 120-180px height\n├─────────────────────────────────────┤\n│                                     │\n│    Past lyrics (30% opacity)        │\n│                                     │\n│  ╔═══════════════════════════════╗ │\n│  ║   C              G            ║ │  ← Active line\n│  ║   Here comes the sun ◆ doo   ║ │  ← ◆ = current syllable\n│  ╚═══════════════════════════════╝ │\n│                                     │\n│    Future lyrics (100% opacity)     │\n│                                     │\n└─────────────────────────────────────┘\n```\n\n**Props:**\n```typescript\ninterface TeleprompterViewProps {\n  songMap: SongMap;\n  transpose: number;\n  capo: number;\n  chordDisplay: 'off' | 'names' | 'diagrams';\n  jobId?: string;\n}\n```\n\n---\n\n#### 2. AudioPlayer ✨ NEW\n**File:** `frontend/components/AudioPlayer.tsx`\n\n**Purpose:** Full-featured audio player with playback controls\n\n**Features:**\n- Play/pause button\n- Progress bar (draggable seek)\n- Volume control (slider + mute)\n- Time display (MM:SS / MM:SS)\n- Real-time sync with lyrics\n\n**UI Elements:**\n- **Progress Bar:** Cyan fill, gray background, draggable\n- **Play/Pause:** Cyan button, black text, icons ▶ ⏸\n- **Volume:** Slider (0.0-1.0), mute button 🔇 🔉 🔊\n- **Time:** Monospace font, white text\n\n**Container:** Gray-800 background, 16px padding, 8px radius\n\n**Props:**\n```typescript\ninterface AudioPlayerProps {\n  audioUrl: string;\n  onTimeUpdate: (currentTime: number) => void;\n  onDurationChange?: (duration: number) => void;\n  onPlayStateChange?: (isPlaying: boolean) => void;\n}\n```\n\n---\n\n#### 3. StemSelector ✨ NEW\n**File:** `frontend/components/StemSelector.tsx`\n\n**Purpose:** Toggle between audio stems (vocals, drums, bass, etc.)\n\n**Features:**\n- 5 stem types: Full Mix, Vocals, Bass, Drums, Other\n- Loading states (spinner icon)\n- Availability check (HEAD request)\n- Active state highlighting\n\n**Button States:**\n- **Selected:** Cyan background, black text, scale 105%, play icon ▶\n- **Unselected:** Gray-700 background, white text, hover gray-600\n- **Loading:** 50% opacity, spinning clock ⌛\n- **Unavailable:** 60% opacity, grayed out\n\n**Props:**\n```typescript\ninterface StemSelectorProps {\n  jobId: string;\n  baseUrl?: string;\n  onStemChange: (stemUrl: string, stemType: StemType) => void;\n}\n\ntype StemType = 'original' | 'vocals' | 'bass' | 'drums' | 'other';\n```\n\n---\n\n#### 4. Full Chart (Song Editor)\n**File:** `frontend/components/BlueprintView.tsx`\n\n**Purpose:** Document-style editor for song structure and chords\n\n**Features:**\n- Inline editing (click to edit)\n- Edit title, artist, lyrics, chords\n- Section headers (Verse, Chorus, etc.)\n- Chord autocomplete (planned Sprint 4)\n- Drag-to-reorder sections (planned Sprint 4)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│  Song Title (editable)              │\n│  Artist Name (editable)             │\n│  Key: C Major | BPM: 120            │\n├─────────────────────────────────────┤\n│  ┌─ [ Verse 1 ] ─────────────────┐ │\n│  │  C            G                │ │\n│  │  Here comes the sun           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  ┌─ [ Chorus ] ──────── [⋮] ─────┐ │  ← Drag handle\n│  │  ...                           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  [+ Add Section]                    │\n└─────────────────────────────────────┘\n```\n\n---\n\n#### 5. LibraryView\n**File:** `frontend/components/LibraryView.tsx`\n\n**Purpose:** Song search and library management\n\n**Features:**\n- Instant search (title, artist, lyrics, tags)\n- Filter by genre, key, BPM, difficulty\n- Sort by title, date added, last played\n- Quick actions: Play, Edit, Delete\n- Song cards with metadata\n\n**Search:** Fuzzy matching, autocomplete (planned Sprint 4)\n\n---\n\n#### 6. SettingsPanel\n**File:** `frontend/components/SettingsPanel.tsx`\n\n**Purpose:** Quick access to performance controls\n\n**Features:**\n- Chord display mode (Off, Names, Diagrams)\n- Font size slider (50%-150%)\n- Transpose (-12 to +12)\n- Capo (0-12 frets)\n- Settings presets (planned Sprint 4)\n- High contrast mode (planned Sprint 3)\n\n**Layout:** Slide-in from left, 384px width\n\n---\n\n#### 7. Header\n**File:** `frontend/components/Header.tsx`\n\n**Elements:**\n- Settings button (gear icon, cyan background)\n- Upload Song button\n- Demo button\n- Song title/artist display (center)\n\n---\n\n#### 8. ChordDiagram\n**File:** `frontend/components/ChordDiagram.tsx`\n\n**Purpose:** Guitar chord visualization\n\n**Elements:**\n- Fretboard grid\n- Finger positions\n- Chord name label\n\n---\n\n### Component Hierarchy\n\n```\nApp (State Manager)\n├── Header\n│   ├── Settings Button → Opens SettingsPanel\n│   ├── Upload Button → Triggers upload flow\n│   └── Song Title (center)\n│\n├── Main Content (View-Switched)\n│   ├── TeleprompterView (Performance Mode)\n│   │   ├── Audio Controls Bar ✨ NEW\n│   │   │   ├── StemSelector ✨ NEW\n│   │   │   └── AudioPlayer ✨ NEW\n│   │   └── Lyrics Display (Living Chart)\n│   │\n│   ├── Full Chart (Edit Mode)\n│   └── SongMapDemo\n│\n├── Footer\n│\n└── SettingsPanel (Modal)\n    └── LibraryView\n```\n\n---\n\n## 📋 Feature Status\n\n### ✅ Complete (Sprint 1-2)\n\n| Feature | Component | Status |\n|---------|-----------|--------|\n| **Teleprompter display** | TeleprompterView | ✅ Complete |\n| **Syllable highlighting** | TeleprompterView | ✅ Complete |\n| **Auto-scroll** | TeleprompterView | ✅ Complete |\n| **Chord display** | TeleprompterView | ✅ Complete |\n| **Audio playback** | AudioPlayer | ✅ Complete |\n| **Stem selection** | StemSelector | ✅ Complete |\n| **Progress bar** | AudioPlayer | ✅ Complete |\n| **Volume control** | AudioPlayer | ✅ Complete |\n| **Song Map generation** | Backend | ✅ Complete |\n| **Library management** | LibraryView | ✅ Complete |\n| **Settings panel** | SettingsPanel | ✅ Complete |\n| **Full Chart editor** | BlueprintView | ✅ Complete |\n\n### 🔨 In Progress\n\n| Feature | Target | Current | Sprint |\n|---------|--------|---------|--------|\n| **60fps rendering** | 60fps | 50fps | Sprint 3 |\n| **Settings speed** | <2s | ~4s | Sprint 3 |\n\n### 📋 Planned\n\n#### Sprint 3 (Oct 8-21): Performance & Accessibility\n- [ ] 60fps rendering optimization\n- [ ] Auto-center active line (50% viewport)\n- [ ] Keyboard navigation (8 shortcuts)\n- [ ] ARIA labels and semantic HTML\n- [ ] High contrast mode\n- [ ] Focus indicators\n- [ ] Reduced motion mode\n\n#### Sprint 4 (Oct 22 - Nov 4): Enhanced Editing + SongPrep Experimentation\n- [ ] Chord autocomplete popup\n- [ ] Drag-to-reorder sections\n- [ ] Real-time chord validation\n- [ ] Emergency font adjust (double-tap)\n- [ ] Library autocomplete search\n- [ ] Settings presets\n- [ ] **SongPrep Integration Research** (NEW)\n  - [ ] Clone SongPrep repository and set up environment\n  - [ ] Download 7B model weights from HuggingFace\n  - [ ] Test on 10 sample songs\n  - [ ] Benchmark inference speed and accuracy\n  - [ ] Compare section detection vs current heuristics\n  - [ ] Assess GPU requirements and resource impact\n  - [ ] Document findings and integration recommendations\n\n#### Sprint 5 (Nov 5-18): Polish & Testing + SongPrep Integration\n- [ ] Micro-interactions and animations\n- [ ] Loading states (skeleton screens)\n- [ ] User testing\n- [ ] Bug fixes and polish\n- [ ] **SongPrep Integration** (if Sprint 4 experiments successful)\n  - [ ] Create `backend/src/services/songprep/` module\n  - [ ] Implement parser for SongPrep output → Song Map format\n  - [ ] Update orchestrator for parallel processing\n  - [ ] Add confidence scoring to sections\n  - [ ] E2E testing: Audio → SongPrep → Living Chart\n  - [ ] Performance optimization (GPU, caching)\n\n### 🔮 Future (Post-MVP)\n\n- **Phase 2 (Q1 2026):** Setlist management, mobile support, SongPrep fine-tuning\n- **Phase 3 (Q2 2026):** Collaborative editing, cloud sync, genre-specific structure models\n- **Phase 4 (Q3 2026):** AI accompaniment (drums, bass, keys)\n- **Phase 5 (Q4 2026):** Voice commands, custom training datasets\n\n---\n\n## 🗺️ Roadmap\n\n### MVP Timeline\n\n| Sprint | Dates | Theme | Deliverables |\n|--------|-------|-------|--------------|\n| **1-2** | ✅ Complete | Backend + Audio | Analysis pipeline, audio playback, stems |\n| **3** | Oct 8-21 | Performance + A11y | 60fps, keyboard nav, ARIA, high contrast |\n| **4** | Oct 22-Nov 4 | Enhanced Editing | Chord autocomplete, drag sections, emergency font |\n| **5** | Nov 5-18 | Polish + Testing | Animations, loading states, user testing |\n| **MVP** | Nov 22 | Launch | Feature complete, accessible, bug-free |\n\n### Sprint 3 Breakdown (Oct 8-21)\n\n**Week 1: Performance**\n1. Optimize TeleprompterView rendering (virtual scrolling)\n2. Add syllable pulse animation\n3. Implement auto-centering (50% viewport)\n\n**Week 2: Accessibility**\n1. Keyboard navigation (8 shortcuts)\n2. ARIA labels on all elements\n3. High contrast mode\n4. Focus indicators\n\n**Acceptance Criteria:**\n- [ ] 60fps sustained for 10-min song\n- [ ] All elements keyboard accessible\n- [ ] WCAG AAA contrast ratios\n- [ ] Lighthouse accessibility score: 95+\n\n---\n\n## 🔧 Developer Guide\n\n### Project Structure\n\n```\nPerformia/\n├── frontend/                  # React frontend\n│   ├── components/           # React components\n│   ├── services/             # Library service, etc.\n│   ├── hooks/                # Custom hooks\n│   ├── data/                 # Mock data\n│   ├── types.ts              # TypeScript definitions\n│   └── index.css             # Global styles\n│\n├── backend/                   # Python backend\n│   ├── src/\n│   │   ├── main.py           # FastAPI server\n│   │   ├── services/         # Audio analysis\n│   │   └── schemas/          # JSON schemas\n│   └── requirements.txt\n│\n└── PERFORMIA_MASTER_DOCS.md  # This file\n```\n\n### Development Workflow\n\n1. **Start Backend:**\n   ```bash\n   cd backend\n   python src/main.py\n   ```\n\n2. **Start Frontend:**\n   ```bash\n   cd frontend\n   npm run dev\n   ```\n\n3. **Make Changes:**\n   - Hot reload enabled (Vite)\n   - Backend restarts on file change\n\n4. **Test:**\n   ```bash\n   # Frontend\n   npm test\n\n   # Backend\n   pytest\n   ```\n\n5. **Commit:**\n   ```bash\n   git add .\n   git commit -m \"feat: description\"\n   git push\n   ```\n\n### Key Files to Know\n\n| File | Purpose |\n|------|---------|\n| `frontend/App.tsx` | Main app component, state management |\n| `frontend/components/TeleprompterView.tsx` | Living Chart display |\n| `frontend/components/AudioPlayer.tsx` | Audio playback controls |\n| `frontend/types.ts` | TypeScript type definitions |\n| `backend/src/main.py` | FastAPI server, routes |\n| `backend/schemas/song_map.schema.json` | Song Map structure |\n\n### Adding a New Component\n\n1. Create file in `frontend/components/`\n2. Define TypeScript interface for props\n3. Implement component with accessibility (ARIA labels)\n4. Add to parent component\n5. Update this documentation\n\n### Debugging Tips\n\n**Frontend:**\n- React DevTools for component tree\n- Console.log sparingly (use breakpoints)\n- Check Network tab for API calls\n\n**Backend:**\n- FastAPI auto-docs: `http://localhost:8000/docs`\n- Check logs for errors\n- Use Python debugger (pdb)\n\n**Performance:**\n- Chrome DevTools Performance tab\n- Target: 60fps (16.67ms per frame)\n- Check for layout thrashing\n\n---\n\n## ♿ Accessibility\n\n### WCAG Compliance\n\n**Target:** WCAG 2.1 AA minimum, AAA for critical elements\n\n### Contrast Ratios\n\n| Element | Ratio | Standard |\n|---------|-------|----------|\n| Lyrics | 16:1 | AAA |\n| Chords | 7:1 | AAA |\n| UI Controls | 4.5:1 | AA |\n\n### Keyboard Navigation\n\n| Key | Action | Context |\n|-----|--------|---------|\n| **Space** | Play/pause | Teleprompter |\n| **←/→** | Prev/next section | Teleprompter |\n| **Cmd+,** | Open settings | Global |\n| **Cmd+L** | Open library | Global |\n| **Cmd+E** | Toggle edit mode | Global |\n| **Esc** | Close modal | Global |\n| **Tab** | Navigate controls | Settings |\n| **Cmd+↑/↓** | Font size ±10% | Teleprompter |\n\n### Screen Reader Support\n\n- Semantic HTML (`<header>`, `<main>`, `<nav>`)\n- ARIA labels on all interactive elements\n- ARIA live regions for dynamic content\n- Announce section changes and playback state\n\n### Visual Accessibility\n\n- **High contrast mode** (black-on-white toggle)\n- **Focus indicators** (2px cyan outline)\n- **Reduced motion** (disable animations)\n- **Minimum touch targets** (44x44px)\n\n### Testing Checklist\n\n- [ ] Tab through all interactive elements\n- [ ] Test with screen reader (VoiceOver/NVDA)\n- [ ] Check contrast with WCAG Color Contrast Checker\n- [ ] Test reduced motion preference\n- [ ] Verify focus indicators visible\n\n---\n\n## 📊 Success Metrics\n\n### Quantitative Targets\n\n| Metric | Target | Current | Status |\n|--------|--------|---------|--------|\n| **Time to first performance** | <30s | ✅ 25s | ✅ Met |\n| **Song search speed** | <5s | ✅ 3s | ✅ Met |\n| **Settings adjust speed** | <2s | 🔨 4s | 🔨 In progress |\n| **Frame rate** | 60fps | 🔨 50fps | 🔨 In progress |\n| **Audio latency** | <50ms | ✅ 35ms | ✅ Met |\n| **Analysis speed** | <30s/song | ✅ 22s | ✅ Met |\n| **Chord accuracy** | 90%+ | ✅ 92% | ✅ Met |\n| **Lyric accuracy** | 95%+ | ✅ 96% | ✅ Met |\n\n### Qualitative Targets\n\n- **Ease of use:** 4.5+ stars (out of 5)\n- **Feature discovery:** 80%+ without tutorial\n- **Visual clarity:** 95%+ \"easy to read\"\n- **Performance satisfaction:** 90%+ \"feels instant\"\n\n### Analytics to Track\n\n1. Time to first performance\n2. Songs uploaded per user\n3. Most used features\n4. Error rate\n5. Session duration\n6. Return rate (weekly active)\n\n---\n\n## 🔍 Frequently Asked Questions\n\n### General\n\n**Q: What audio formats are supported?**\nA: WAV, MP3, M4A, FLAC\n\n**Q: How long does song analysis take?**\nA: ~30 seconds per song (varies by length)\n\n**Q: Can I edit the auto-generated chords?**\nA: Yes, use Full Chart to edit chords inline\n\n**Q: Does it work offline?**\nA: Not yet (planned for Phase 3)\n\n### Technical\n\n**Q: Why 60fps target?**\nA: Smooth scrolling is critical for reading during performance. 60fps = 16.67ms per frame.\n\n**Q: Canvas vs DOM for rendering?**\nA: Currently DOM. Will optimize first, consider Canvas only if needed (accessibility trade-off).\n\n**Q: How does syllable sync work?**\nA: RequestAnimationFrame checks current audio time, finds matching syllable, updates highlight.\n\n**Q: Why Performia cyan?**\nA: High contrast with warm amber chords, signals \"now\", cool color stands out.\n\n---\n\n## 📝 Contribution Guidelines\n\n### Code Style\n\n- **TypeScript:** Strict mode, explicit types\n- **React:** Functional components, hooks\n- **CSS:** Tailwind utility classes, avoid inline styles\n- **Naming:** camelCase for variables, PascalCase for components\n\n### Commit Messages\n\n```\nfeat: Add emergency font adjust gesture\nfix: Resolve audio sync latency issue\ndocs: Update component API reference\nrefactor: Optimize TeleprompterView rendering\ntest: Add unit tests for chord validation\n```\n\n### Pull Requests\n\n1. Create feature branch: `git checkout -b feat/my-feature`\n2. Make changes and commit\n3. Push: `git push -u origin feat/my-feature`\n4. Open PR with description\n5. Request review\n6. Merge after approval\n\n---\n\n## 🐛 Known Issues & Limitations\n\n### Current Limitations\n\n1. **Desktop only** (mobile support in Phase 2)\n2. **Local storage** (no cloud sync yet)\n3. **No collaboration** (single user editing)\n4. **English lyrics only** (multi-language in future)\n\n### Known Bugs\n\n*None currently tracked for MVP*\n\n### Workarounds\n\n**Issue:** Font size changes lag\n**Workaround:** Use preset sizes instead of slider\n\n**Issue:** Large songs (>10min) slow down\n**Workaround:** Virtual scrolling coming in Sprint 3\n\n---\n\n## 📚 Additional Resources\n\n### External Links\n\n- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)\n- [React Performance](https://react.dev/learn/render-and-commit)\n- [Tailwind CSS Docs](https://tailwindcss.com/docs)\n- [FastAPI Docs](https://fastapi.tiangolo.com/)\n- **[SongPrep Repository](https://github.com/tencent-ailab/SongPrep)** - Song structure parsing\n- **[SongPrep Paper](https://arxiv.org/abs/2509.17404)** - Technical details\n\n### Internal Files\n\n- `backend/schemas/song_map.schema.json` - Song Map structure\n- `frontend/types.ts` - TypeScript definitions\n- `.claude/CLAUDE.md` - Agent SDK instructions\n- **`docs/research/SONGPREP_ANALYSIS.md`** - SongPrep integration research\n\n---\n\n## 📅 Document History\n\n| Version | Date | Changes |\n|---------|------|---------|\n| 3.0 | Oct 1, 2025 | Consolidated all docs into master file |\n| 2.0 | Oct 1, 2025 | Added AudioPlayer & StemSelector specs |\n| 1.0 | Sep 30, 2025 | Initial documentation structure |\n\n---\n\n## 🎯 Core Principle\n\n> **\"The best interface for performance is no interface at all.\"**\n\nEvery decision must answer:\n**\"Does this help the musician perform better, or does it distract?\"**\n\nIf it distracts → Cut it.\nIf it helps → Polish it until it's invisible.\n\n---\n\n**Maintained by:** Performia Development Team\n**Next Review:** End of Sprint 3 (Oct 21, 2025)\n**Questions?** Check the FAQ or open an issue\n"
+}

--- a/ui/server/viztrtr-workspaces/proj_1759693550486_qz7vsnn/product-spec.json
+++ b/ui/server/viztrtr-workspaces/proj_1759693550486_qz7vsnn/product-spec.json
@@ -1,0 +1,529 @@
+{
+  "projectId": "proj_1759693550486_qz7vsnn",
+  "version": 1,
+  "createdAt": "2025-10-05T19:52:25.605Z",
+  "lastUpdated": "2025-10-05T19:52:25.605Z",
+  "productVision": "Performia is a revolutionary music performance system that transforms live performance by following musicians in real-time through AI-powered audio analysis and an intelligent Living Chart teleprompter, enabling artists to focus on their artistry without worrying about forgetting lyrics or chords.",
+  "targetUsers": [
+    "Live performers (vocalists, guitarists, bands) who perform 3-4 gigs per week and need large, readable fonts from 6ft away with zero distractions",
+    "Rehearsal musicians learning new songs who need to edit chords and song structure while practicing with isolated stems",
+    "Casual hobbyists practicing at home who need a simple, intuitive interface to explore demo songs"
+  ],
+  "components": {
+    "TeleprompterView": {
+      "purpose": "Fullscreen Living Chart display with real-time syllable highlighting and auto-scrolling for distraction-free performance",
+      "userStories": [
+        "As a live performer, I need to see lyrics in large, readable text from 6 feet away so I can perform without moving closer to the screen",
+        "As a vocalist, I need the current syllable highlighted in real-time so I always know exactly where I am in the song",
+        "As a musician, I need the active line centered on screen so I don't have to search for my place",
+        "As a guitarist, I need to see chord names above lyrics so I can play the correct chords at the right time"
+      ],
+      "designPriorities": [
+        "Maximum readability from distance",
+        "Zero-latency feel",
+        "Minimal visual distraction",
+        "Smooth auto-scrolling"
+      ],
+      "focusAreas": [
+        "Font size control (2.5rem to 6rem range)",
+        "Syllable highlighting with cyan glow effect",
+        "Auto-centering active line at 50% viewport",
+        "Past lyrics dimmed to 30% opacity",
+        "Chord display options (off, names, diagrams)",
+        "60fps rendering performance",
+        "Virtual scrolling for long songs"
+      ],
+      "avoidAreas": [
+        "Complex animations that distract from lyrics",
+        "UI chrome visible during performance",
+        "Small or hard-to-read fonts",
+        "Jerky or stuttering scroll behavior"
+      ],
+      "acceptanceCriteria": [
+        "Font size range 2.5rem to 6rem with default at 3.5rem",
+        "Syllable highlighting latency under 100ms",
+        "Active line centered at 50% viewport height",
+        "Sustained 60fps for 10+ minute songs",
+        "WCAG AAA contrast ratio (16:1) for lyrics",
+        "Readable from 6 feet away at default size"
+      ],
+      "status": "active"
+    },
+    "AudioPlayer": {
+      "purpose": "Full-featured audio playback controls with precise seeking, volume control, and real-time sync with lyrics",
+      "userStories": [
+        "As a musician, I need to play/pause audio quickly so I can control playback during practice",
+        "As a rehearsal musician, I need to seek to specific parts of the song so I can practice difficult sections",
+        "As a performer, I need to adjust volume levels so I can balance with my live playing",
+        "As a user, I need to see current playback time so I know where I am in the song"
+      ],
+      "designPriorities": [
+        "Instant responsiveness",
+        "Large touch targets",
+        "Clear visual feedback",
+        "Precise seeking control"
+      ],
+      "focusAreas": [
+        "Play/pause button with clear icon states",
+        "Draggable progress bar with cyan fill",
+        "Volume slider with mute toggle",
+        "Monospace time display (MM:SS format)",
+        "Real-time sync with syllable highlighting",
+        "Audio latency under 50ms",
+        "Keyboard shortcut support (spacebar)"
+      ],
+      "avoidAreas": [
+        "Small, hard-to-click controls",
+        "Delayed audio response",
+        "Confusing progress bar interaction",
+        "Hidden volume controls"
+      ],
+      "acceptanceCriteria": [
+        "Play/pause responds within 50ms",
+        "Progress bar supports click and drag seeking",
+        "Volume control range 0.0 to 1.0 with mute",
+        "Time display updates at 10Hz minimum",
+        "Touch targets minimum 44x44px",
+        "Keyboard shortcuts functional"
+      ],
+      "status": "active"
+    },
+    "StemSelector": {
+      "purpose": "Toggle between audio stems (full mix, vocals, bass, drums, other) for isolated practice and performance",
+      "userStories": [
+        "As a rehearsal musician, I need to isolate vocal stems so I can practice singing without distraction",
+        "As a guitarist, I need to mute guitar parts so I can practice my own playing",
+        "As a drummer, I need to hear just the drums so I can learn the drum parts",
+        "As a user, I need to see which stems are available so I don't waste time trying unavailable options"
+      ],
+      "designPriorities": [
+        "Clear stem availability status",
+        "Fast stem switching",
+        "Visual feedback for active stem",
+        "Loading state visibility"
+      ],
+      "focusAreas": [
+        "5 stem types clearly labeled",
+        "Loading spinner for stems in progress",
+        "Availability check via HEAD request",
+        "Active stem highlighted with cyan background",
+        "Disabled state for unavailable stems",
+        "Smooth audio transition between stems",
+        "Keyboard navigation support"
+      ],
+      "avoidAreas": [
+        "Confusing stem labels",
+        "Long loading times without feedback",
+        "Audio clicks during stem switching",
+        "Unclear active state"
+      ],
+      "acceptanceCriteria": [
+        "All 5 stem types displayed (Full, Vocals, Bass, Drums, Other)",
+        "Loading state shows spinning icon at 50% opacity",
+        "Active stem has cyan background and scale 105%",
+        "Unavailable stems grayed at 60% opacity",
+        "Stem switching completes within 500ms",
+        "Audio crossfade to prevent clicks"
+      ],
+      "status": "active"
+    },
+    "FullChart": {
+      "purpose": "Document-style song editor for inline editing of title, artist, lyrics, chords, and song structure",
+      "userStories": [
+        "As a musician, I need to edit incorrect lyrics so my performance chart is accurate",
+        "As a guitarist, I need to correct auto-detected chords so I play the right harmonies",
+        "As a band leader, I need to rearrange song sections so the chart matches our arrangement",
+        "As a user, I need to add section labels so I can organize the song structure clearly"
+      ],
+      "designPriorities": [
+        "Inline editing simplicity",
+        "Clear section organization",
+        "Non-destructive editing",
+        "Fast save operations"
+      ],
+      "focusAreas": [
+        "Click-to-edit for all text fields",
+        "Section headers with drag handles",
+        "Chord autocomplete dropdown",
+        "Real-time chord validation",
+        "Add/remove section buttons",
+        "Undo/redo support",
+        "Auto-save on blur"
+      ],
+      "avoidAreas": [
+        "Modal dialogs for simple edits",
+        "Confusing edit mode switching",
+        "Loss of unsaved changes",
+        "Slow save operations"
+      ],
+      "acceptanceCriteria": [
+        "Click any text to enter edit mode",
+        "Chord autocomplete appears within 200ms",
+        "Section drag-to-reorder functional",
+        "Changes save automatically on blur",
+        "Undo/redo supports 50+ actions",
+        "Edit operations complete under 100ms"
+      ],
+      "status": "active"
+    },
+    "LibraryView": {
+      "purpose": "Song search and library management with instant filtering, sorting, and quick actions",
+      "userStories": [
+        "As a performer, I need to search my song library quickly so I can find songs for my setlist",
+        "As a user, I need to filter songs by key and BPM so I can find songs that match my vocal range",
+        "As a band member, I need to see song metadata at a glance so I can choose appropriate songs",
+        "As a musician, I need quick access to play, edit, and delete actions so I can manage my library efficiently"
+      ],
+      "designPriorities": [
+        "Instant search results",
+        "Clear visual hierarchy",
+        "Fast filtering and sorting",
+        "Scannable song cards"
+      ],
+      "focusAreas": [
+        "Instant search with fuzzy matching",
+        "Filter by genre, key, BPM, difficulty",
+        "Sort by title, date, last played",
+        "Song cards with thumbnail and metadata",
+        "Quick action buttons (Play, Edit, Delete)",
+        "Search within 5 seconds target",
+        "Keyboard navigation for power users"
+      ],
+      "avoidAreas": [
+        "Slow search performance",
+        "Cluttered song cards",
+        "Hidden filter options",
+        "Confusing quick actions"
+      ],
+      "acceptanceCriteria": [
+        "Search results appear within 5 seconds",
+        "Fuzzy matching supports typos",
+        "Filter combinations work correctly",
+        "Song cards show title, artist, key, BPM, genre",
+        "Quick actions accessible with single click",
+        "Keyboard shortcuts for common actions"
+      ],
+      "status": "active"
+    },
+    "SettingsPanel": {
+      "purpose": "Quick access to performance controls including chord display, font size, transpose, and capo settings",
+      "userStories": [
+        "As a performer, I need to adjust font size quickly so I can see lyrics from my performance distance",
+        "As a guitarist, I need to transpose songs so they match my vocal range",
+        "As a capo user, I need to set capo position so chords display correctly for my playing",
+        "As a musician, I need to toggle chord display modes so I can choose between names and diagrams"
+      ],
+      "designPriorities": [
+        "Fast settings changes",
+        "Clear visual feedback",
+        "Non-modal when possible",
+        "Settings persistence"
+      ],
+      "focusAreas": [
+        "Font size slider (50% to 150%)",
+        "Transpose selector (-12 to +12 semitones)",
+        "Capo selector (0 to 12 frets)",
+        "Chord display mode toggle (Off, Names, Diagrams)",
+        "Settings presets for common configurations",
+        "High contrast mode toggle",
+        "Settings response under 2 seconds"
+      ],
+      "avoidAreas": [
+        "Modal blocking performance view",
+        "Slow settings application",
+        "Lost settings between sessions",
+        "Confusing control layouts"
+      ],
+      "acceptanceCriteria": [
+        "Settings panel slides in from left at 384px width",
+        "Font size changes apply immediately",
+        "Transpose updates all chords correctly",
+        "Capo setting adjusts chord display",
+        "Settings persist across sessions",
+        "All changes complete within 2 seconds"
+      ],
+      "status": "active"
+    },
+    "Header": {
+      "purpose": "Top navigation bar with settings access, upload button, demo button, and song title display",
+      "userStories": [
+        "As a user, I need quick access to settings so I can adjust preferences during performance",
+        "As a musician, I need to upload new songs easily so I can expand my library",
+        "As a new user, I need to load demo songs so I can explore features without uploading",
+        "As a performer, I need to see the current song title so I know what I'm performing"
+      ],
+      "designPriorities": [
+        "Always accessible",
+        "Clear visual hierarchy",
+        "Minimal height to maximize content area",
+        "Consistent placement"
+      ],
+      "focusAreas": [
+        "Settings button with gear icon and cyan background",
+        "Upload Song button with clear label",
+        "Demo button for first-time users",
+        "Centered song title and artist display",
+        "Consistent 64-80px height",
+        "Responsive layout for different screen sizes",
+        "Keyboard shortcuts for all actions"
+      ],
+      "avoidAreas": [
+        "Excessive height stealing content space",
+        "Hidden critical functions",
+        "Cluttered button arrangement",
+        "Unclear button purposes"
+      ],
+      "acceptanceCriteria": [
+        "Header height between 64-80px",
+        "Settings button opens panel within 100ms",
+        "Upload button triggers file picker",
+        "Song title centered and truncated if needed",
+        "All buttons minimum 44x44px touch targets",
+        "Keyboard shortcuts functional"
+      ],
+      "status": "active"
+    },
+    "ChordDiagram": {
+      "purpose": "Visual guitar chord representation with fretboard grid and finger positions",
+      "userStories": [
+        "As a guitarist, I need to see chord diagrams so I can learn unfamiliar chord shapes",
+        "As a beginner, I need clear finger position markers so I know where to place my fingers",
+        "As a musician, I need chord names labeled clearly so I can identify chords quickly",
+        "As a performer, I need chord diagrams sized appropriately so I can read them during performance"
+      ],
+      "designPriorities": [
+        "Clear finger positions",
+        "Readable from distance",
+        "Standard guitar notation",
+        "Compact size"
+      ],
+      "focusAreas": [
+        "6-string fretboard grid (typically 4-5 frets shown)",
+        "Finger position dots with numbers",
+        "Open/muted string indicators at top",
+        "Chord name label above diagram",
+        "Fret number indication for barre chords",
+        "High contrast for visibility",
+        "Consistent sizing with lyrics"
+      ],
+      "avoidAreas": [
+        "Overly complex diagrams",
+        "Too small to read from distance",
+        "Inconsistent notation",
+        "Cluttered visual design"
+      ],
+      "acceptanceCriteria": [
+        "Diagram shows 6 strings and 4-5 frets",
+        "Finger positions clearly marked with dots",
+        "Open strings marked with 'O', muted with 'X'",
+        "Chord name displayed above diagram",
+        "Diagram size proportional to font size setting",
+        "WCAG AA contrast for all elements"
+      ],
+      "status": "active"
+    },
+    "UploadFlow": {
+      "purpose": "Guided workflow for uploading audio files and monitoring analysis progress",
+      "userStories": [
+        "As a musician, I need to drag-and-drop audio files so uploading is quick and easy",
+        "As a user, I need to see analysis progress so I know how long to wait",
+        "As a performer, I need clear error messages if upload fails so I can fix the problem",
+        "As a user, I need to know when my song is ready so I can start practicing"
+      ],
+      "designPriorities": [
+        "Simple upload process",
+        "Clear progress feedback",
+        "Error handling",
+        "Fast analysis"
+      ],
+      "focusAreas": [
+        "Drag-and-drop zone with hover state",
+        "File format validation (WAV, MP3, M4A, FLAC)",
+        "Progress bar with percentage and status",
+        "Analysis time estimate display",
+        "Error messages with actionable steps",
+        "Success state with play button",
+        "Cancel upload option"
+      ],
+      "avoidAreas": [
+        "Confusing upload interface",
+        "No progress feedback",
+        "Cryptic error messages",
+        "Long waits without updates"
+      ],
+      "acceptanceCriteria": [
+        "Drag-and-drop and click-to-browse both work",
+        "Supported formats validated before upload",
+        "Progress updates at least every 2 seconds",
+        "Analysis completes within 30 seconds per song",
+        "Errors show clear, actionable messages",
+        "Success state transitions to playback automatically"
+      ],
+      "status": "active"
+    },
+    "AudioControlsBar": {
+      "purpose": "Integrated control bar combining audio player and stem selector for performance mode",
+      "userStories": [
+        "As a performer, I need all audio controls in one place so I can focus on the lyrics",
+        "As a rehearsal musician, I need quick access to both playback and stem controls so I can practice efficiently",
+        "As a user, I need the control bar to stay visible so I can always access playback functions",
+        "As a performer, I need the control bar to be unobtrusive so it doesn't distract from lyrics"
+      ],
+      "designPriorities": [
+        "Integrated layout",
+        "Always accessible",
+        "Minimal visual weight",
+        "Logical grouping"
+      ],
+      "focusAreas": [
+        "Fixed height 120-180px",
+        "Horizontal layout with stem selector on left",
+        "Audio player controls in center",
+        "Volume and time on right",
+        "Gray-800 background to differentiate from lyrics",
+        "16px padding for touch targets",
+        "Responsive layout for narrower screens"
+      ],
+      "avoidAreas": [
+        "Excessive height",
+        "Cluttered control arrangement",
+        "Overlapping lyrics area",
+        "Hard-to-reach controls"
+      ],
+      "acceptanceCriteria": [
+        "Bar height between 120-180px",
+        "All controls accessible without scrolling",
+        "Stem selector and player visually grouped",
+        "Controls respond within 100ms",
+        "Bar remains fixed at top of teleprompter",
+        "Responsive layout maintains usability"
+      ],
+      "status": "active"
+    },
+    "KeyboardShortcuts": {
+      "purpose": "Comprehensive keyboard navigation for power users and accessibility",
+      "userStories": [
+        "As a power user, I need keyboard shortcuts so I can navigate without touching the mouse",
+        "As a performer, I need emergency font controls so I can adjust size during performance",
+        "As a musician with mobility limitations, I need full keyboard access so I can use the app independently",
+        "As a user, I need discoverable shortcuts so I can learn them easily"
+      ],
+      "designPriorities": [
+        "Full keyboard accessibility",
+        "Standard shortcut patterns",
+        "Discoverable shortcuts",
+        "No conflicts with browser shortcuts"
+      ],
+      "focusAreas": [
+        "Spacebar for play/pause",
+        "Arrow keys for section navigation",
+        "Cmd/Ctrl+, for settings",
+        "Cmd/Ctrl+L for library",
+        "Cmd/Ctrl+E for edit mode",
+        "Escape to close modals",
+        "Cmd/Ctrl+Up/Down for font size",
+        "Tab for control navigation"
+      ],
+      "avoidAreas": [
+        "Non-standard key combinations",
+        "Conflicting with browser shortcuts",
+        "Hidden shortcuts without documentation",
+        "Shortcuts that only work in certain modes"
+      ],
+      "acceptanceCriteria": [
+        "All 8 documented shortcuts functional",
+        "Shortcuts work in all relevant contexts",
+        "Visual feedback for shortcut actions",
+        "Shortcuts listed in settings panel",
+        "No conflicts with browser defaults",
+        "Focus indicators visible for tab navigation"
+      ],
+      "status": "planned"
+    },
+    "AccessibilityFeatures": {
+      "purpose": "Comprehensive accessibility support including screen readers, high contrast, and reduced motion",
+      "userStories": [
+        "As a visually impaired musician, I need screen reader support so I can use the app independently",
+        "As a user with photosensitivity, I need reduced motion mode so animations don't cause discomfort",
+        "As a user with low vision, I need high contrast mode so I can read all text clearly",
+        "As a keyboard-only user, I need focus indicators so I know where I am in the interface"
+      ],
+      "designPriorities": [
+        "WCAG 2.1 AA minimum",
+        "Screen reader compatibility",
+        "Keyboard navigation",
+        "Visual accessibility options"
+      ],
+      "focusAreas": [
+        "Semantic HTML elements",
+        "ARIA labels on all interactive elements",
+        "ARIA live regions for dynamic content",
+        "High contrast mode toggle",
+        "Reduced motion mode respecting prefers-reduced-motion",
+        "2px cyan focus indicators",
+        "Minimum 44x44px touch targets",
+        "16:1 contrast for lyrics, 7:1 for chords"
+      ],
+      "avoidAreas": [
+        "Div soup without semantic meaning",
+        "Missing ARIA labels",
+        "Invisible focus indicators",
+        "Motion without respect for user preferences"
+      ],
+      "acceptanceCriteria": [
+        "Lighthouse accessibility score 95+",
+        "All elements keyboard accessible",
+        "Screen reader announces all state changes",
+        "High contrast mode provides 21:1 minimum ratio",
+        "Reduced motion disables all animations",
+        "Focus indicators visible on all interactive elements",
+        "WCAG AAA contrast for critical elements"
+      ],
+      "status": "in-progress"
+    }
+  },
+  "globalConstraints": {
+    "accessibility": [
+      "WCAG 2.1 Level AA minimum compliance",
+      "WCAG 2.1 Level AAA for lyrics and chords",
+      "Screen reader support (VoiceOver, NVDA)",
+      "Full keyboard navigation with visible focus indicators",
+      "Semantic HTML with ARIA labels",
+      "High contrast mode option",
+      "Reduced motion mode respecting user preferences",
+      "Minimum touch targets 44x44px",
+      "ARIA live regions for dynamic content"
+    ],
+    "performance": [
+      "60fps sustained rendering for 10+ minute songs",
+      "Audio latency under 50ms",
+      "Syllable highlighting latency under 100ms",
+      "Settings changes complete within 2 seconds",
+      "Song analysis complete within 30 seconds",
+      "Search results within 5 seconds",
+      "Time to first performance under 30 seconds",
+      "Zero layout thrashing during scroll"
+    ],
+    "browser": [
+      "Chrome 90+",
+      "Safari 14+",
+      "Firefox 88+",
+      "Edge 90+",
+      "Desktop only (mobile in Phase 2)",
+      "Minimum screen resolution 1280x720"
+    ],
+    "design": [
+      "Performance-first design philosophy",
+      "Zero-latency feel for all interactions",
+      "Progressive disclosure of complexity",
+      "Musician mental model (sections, keys, chords)",
+      "Near-black backgrounds (rgb(10, 10, 12)) for stage use",
+      "Performia cyan (rgb(6, 182, 212)) as primary accent",
+      "Warm amber (rgb(250, 204, 21)) for chords",
+      "Tailwind CSS 4 utility classes",
+      "Consistent spacing system (4px base unit)",
+      "Typography scale optimized for distance reading"
+    ]
+  },
+  "originalPRD": "# 🎵 Performia - Complete Documentation\n\n**Version:** 3.0\n**Last Updated:** October 1, 2025\n**Status:** Living Document\n\n---\n\n## 📖 Table of Contents\n\n### Quick Navigation\n- [🎯 Product Overview](#-product-overview)\n- [🚀 Quick Start](#-quick-start)\n- [🏗️ Architecture](#️-architecture)\n- [🎨 Design System](#-design-system)\n- [🧩 Component Library](#-component-library)\n- [📋 Feature Status](#-feature-status)\n- [🗺️ Roadmap](#️-roadmap)\n- [🔧 Developer Guide](#-developer-guide)\n- [♿ Accessibility](#-accessibility)\n- [📊 Success Metrics](#-success-metrics)\n\n---\n\n## 🎯 Product Overview\n\n### What is Performia?\n\n**Performia** is a revolutionary music performance system that transforms how musicians perform live. By combining real-time audio analysis, AI-powered audio processing, and an intelligent \"Living Chart\" teleprompter, Performia enables musicians to focus on their artistry.\n\n**Core Value Proposition:**\n*\"Never forget lyrics or chords again. Performia follows YOU in real-time.\"*\n\n### Target Users\n\n1. **Live Performers** (Primary)\n   - Vocalists, guitarists, bands\n   - Perform 3-4 gigs per week\n   - Need large fonts readable from 6ft away\n   - Zero distractions during performance\n\n2. **Rehearsal Musicians** (Secondary)\n   - Learning new songs\n   - Need to edit chords and structure\n   - Practice with isolated stems\n\n3. **Casual Hobbyists** (Tertiary)\n   - Home practice\n   - Need simple, intuitive interface\n   - Explore demo songs\n\n### Design Philosophy\n\n> **\"The best interface for performance is no interface at all.\"**\n\n**Core Principles:**\n1. **Performance-First**: UI disappears during performance\n2. **Zero-Latency Feel**: <100ms perceived interaction time\n3. **Musician Mental Model**: Sections, keys, chords\n4. **Progressive Disclosure**: Complexity hidden until needed\n5. **Accessibility by Default**: Works for all musicians\n\n---\n\n## 🚀 Quick Start\n\n### Running Performia\n\n#### Backend (Python + C++)\n```bash\ncd backend\npython -m venv venv\nsource venv/bin/activate  # On Windows: venv\\Scripts\\activate\npip install -r requirements.txt\npython src/main.py\n```\n\nBackend runs on: `http://localhost:8000`\n\n#### Frontend (React + Vite)\n```bash\ncd frontend\nnpm install\nnpm run dev\n```\n\nFrontend runs on: `http://localhost:5001`\n\n### First-Time User Flow\n\n1. **Open Performia** → Demo song \"Yesterday\" loads automatically\n2. **Click Settings** (gear icon) → Adjust font size, transpose\n3. **Click Play** → Watch syllables highlight in real-time\n4. **Upload Song** → Drop audio file, wait ~30s for analysis\n5. **Perform** → Fullscreen lyrics with chords, zero distractions\n\n---\n\n## 🏗️ Architecture\n\n### Tech Stack\n\n**Frontend:**\n- React 19 + TypeScript 5\n- Vite 6 (build tool)\n- Tailwind CSS 4 (styling)\n- React hooks (state management)\n\n**Backend:**\n- Python 3.11 + FastAPI\n- JUCE (C++ audio engine)\n- Librosa (audio analysis)\n- Demucs (stem separation)\n- Whisper (speech recognition / ASR)\n- **SongPrep** (planned - song structure parsing)\n\n### Data Flow\n\n```\n1. Upload Audio → Backend\n2. Analysis Pipeline → Song Map JSON\n3. Frontend → Display Living Chart\n4. Audio Playback → Syllable Sync\n```\n\n### Song Map Schema\n\n```json\n{\n  \"title\": \"Song Title\",\n  \"artist\": \"Artist Name\",\n  \"key\": \"C Major\",\n  \"bpm\": 120,\n  \"sections\": [\n    {\n      \"name\": \"Verse 1\",\n      \"lines\": [\n        {\n          \"syllables\": [\n            {\n              \"text\": \"Hello\",\n              \"startTime\": 0.5,\n              \"duration\": 0.3,\n              \"chord\": \"C\"\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}\n```\n\n### API Endpoints\n\n| Endpoint | Method | Purpose |\n|----------|--------|---------|\n| `/upload` | POST | Upload audio file |\n| `/progress/:jobId` | GET | Analysis progress |\n| `/songmap/:jobId` | GET | Get Song Map JSON |\n| `/audio/:jobId/original` | GET | Get original audio |\n| `/audio/:jobId/stem/:type` | GET | Get stem (vocals, bass, drums, other) |\n\n---\n\n## 🎨 Design System\n\n### Color Palette\n\n#### Performance Mode (Stage)\n```css\n--bg-performance: rgb(10, 10, 12)      /* Near-black, minimal glare */\n--text-lyrics: rgb(240, 240, 245)      /* Cool white, max legibility */\n--chord-inactive: #FACC15              /* Warm amber (WCAG AAA) */\n--chord-active: #06b6d4                /* Performia cyan */\n--highlight-sung: rgba(6, 182, 212, 0.3)  /* Cyan glow */\n```\n\n#### UI Chrome (Controls)\n```css\n--bg-chrome: #111827                   /* Gray-900 */\n--bg-panel: #1f2937                    /* Gray-800 */\n--bg-input: #374151                    /* Gray-700 */\n--accent-primary: #06b6d4              /* Performia cyan */\n--accent-hover: #06d4f1                /* Lighter cyan */\n--accent-success: #22c55e              /* Green */\n--accent-warning: #eab308              /* Yellow */\n--accent-error: #ef4444                /* Red */\n```\n\n### Typography Scale\n\n```css\n/* Teleprompter (Performance) */\n--font-lyrics-default: 3.5rem   /* 56px - Stage optimized */\n--font-lyrics-min: 2.5rem       /* 40px */\n--font-lyrics-max: 6.0rem       /* 96px */\n--font-chord: 2.8rem            /* 45px - 80% ratio maintained */\n\n/* UI Chrome */\n--font-header-1: 2.5rem         /* Song title */\n--font-header-2: 1.875rem       /* Artist */\n--font-body: 1.125rem           /* Editable text */\n--font-control: 1rem            /* Buttons */\n--font-label: 0.875rem          /* Labels */\n--font-caption: 0.75rem         /* Metadata */\n```\n\n### Spacing System\n\n```css\n--space-xs:   4px\n--space-sm:   8px\n--space-md:   16px\n--space-lg:   24px\n--space-xl:   32px\n--space-2xl:  48px\n```\n\n### Border Radius\n\n```css\n--radius-sm:  4px\n--radius-md:  8px\n--radius-lg:  12px\n--radius-xl:  16px\n--radius-full: 9999px  /* Pill shape */\n```\n\n### Shadows\n\n```css\n--shadow-sm: 0 1px 2px rgba(0,0,0,0.05)\n--shadow-md: 0 4px 6px rgba(0,0,0,0.1)\n--shadow-lg: 0 10px 15px rgba(0,0,0,0.1)\n--shadow-xl: 0 20px 25px rgba(0,0,0,0.1)\n--shadow-cyan: 0 10px 15px rgba(6,182,212,0.2)\n```\n\n---\n\n## 🧩 Component Library\n\n### Core Components\n\n#### 1. TeleprompterView (Living Chart)\n**File:** `frontend/components/TeleprompterView.tsx`\n\n**Purpose:** Fullscreen lyrics with real-time syllable highlighting\n\n**Features:**\n- Real-time syllable highlighting\n- Auto-scroll (active line centered)\n- Chord display (names or diagrams)\n- Audio controls integration\n- Font size control (50%-150%)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│ [Audio Controls Bar]                │  ← 120-180px height\n├─────────────────────────────────────┤\n│                                     │\n│    Past lyrics (30% opacity)        │\n│                                     │\n│  ╔═══════════════════════════════╗ │\n│  ║   C              G            ║ │  ← Active line\n│  ║   Here comes the sun ◆ doo   ║ │  ← ◆ = current syllable\n│  ╚═══════════════════════════════╝ │\n│                                     │\n│    Future lyrics (100% opacity)     │\n│                                     │\n└─────────────────────────────────────┘\n```\n\n**Props:**\n```typescript\ninterface TeleprompterViewProps {\n  songMap: SongMap;\n  transpose: number;\n  capo: number;\n  chordDisplay: 'off' | 'names' | 'diagrams';\n  jobId?: string;\n}\n```\n\n---\n\n#### 2. AudioPlayer ✨ NEW\n**File:** `frontend/components/AudioPlayer.tsx`\n\n**Purpose:** Full-featured audio player with playback controls\n\n**Features:**\n- Play/pause button\n- Progress bar (draggable seek)\n- Volume control (slider + mute)\n- Time display (MM:SS / MM:SS)\n- Real-time sync with lyrics\n\n**UI Elements:**\n- **Progress Bar:** Cyan fill, gray background, draggable\n- **Play/Pause:** Cyan button, black text, icons ▶ ⏸\n- **Volume:** Slider (0.0-1.0), mute button 🔇 🔉 🔊\n- **Time:** Monospace font, white text\n\n**Container:** Gray-800 background, 16px padding, 8px radius\n\n**Props:**\n```typescript\ninterface AudioPlayerProps {\n  audioUrl: string;\n  onTimeUpdate: (currentTime: number) => void;\n  onDurationChange?: (duration: number) => void;\n  onPlayStateChange?: (isPlaying: boolean) => void;\n}\n```\n\n---\n\n#### 3. StemSelector ✨ NEW\n**File:** `frontend/components/StemSelector.tsx`\n\n**Purpose:** Toggle between audio stems (vocals, drums, bass, etc.)\n\n**Features:**\n- 5 stem types: Full Mix, Vocals, Bass, Drums, Other\n- Loading states (spinner icon)\n- Availability check (HEAD request)\n- Active state highlighting\n\n**Button States:**\n- **Selected:** Cyan background, black text, scale 105%, play icon ▶\n- **Unselected:** Gray-700 background, white text, hover gray-600\n- **Loading:** 50% opacity, spinning clock ⌛\n- **Unavailable:** 60% opacity, grayed out\n\n**Props:**\n```typescript\ninterface StemSelectorProps {\n  jobId: string;\n  baseUrl?: string;\n  onStemChange: (stemUrl: string, stemType: StemType) => void;\n}\n\ntype StemType = 'original' | 'vocals' | 'bass' | 'drums' | 'other';\n```\n\n---\n\n#### 4. Full Chart (Song Editor)\n**File:** `frontend/components/BlueprintView.tsx`\n\n**Purpose:** Document-style editor for song structure and chords\n\n**Features:**\n- Inline editing (click to edit)\n- Edit title, artist, lyrics, chords\n- Section headers (Verse, Chorus, etc.)\n- Chord autocomplete (planned Sprint 4)\n- Drag-to-reorder sections (planned Sprint 4)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│  Song Title (editable)              │\n│  Artist Name (editable)             │\n│  Key: C Major | BPM: 120            │\n├─────────────────────────────────────┤\n│  ┌─ [ Verse 1 ] ─────────────────┐ │\n│  │  C            G                │ │\n│  │  Here comes the sun           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  ┌─ [ Chorus ] ──────── [⋮] ─────┐ │  ← Drag handle\n│  │  ...                           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  [+ Add Section]                    │\n└─────────────────────────────────────┘\n```\n\n---\n\n#### 5. LibraryView\n**File:** `frontend/components/LibraryView.tsx`\n\n**Purpose:** Song search and library management\n\n**Features:**\n- Instant search (title, artist, lyrics, tags)\n- Filter by genre, key, BPM, difficulty\n- Sort by title, date added, last played\n- Quick actions: Play, Edit, Delete\n- Song cards with metadata\n\n**Search:** Fuzzy matching, autocomplete (planned Sprint 4)\n\n---\n\n#### 6. SettingsPanel\n**File:** `frontend/components/SettingsPanel.tsx`\n\n**Purpose:** Quick access to performance controls\n\n**Features:**\n- Chord display mode (Off, Names, Diagrams)\n- Font size slider (50%-150%)\n- Transpose (-12 to +12)\n- Capo (0-12 frets)\n- Settings presets (planned Sprint 4)\n- High contrast mode (planned Sprint 3)\n\n**Layout:** Slide-in from left, 384px width\n\n---\n\n#### 7. Header\n**File:** `frontend/components/Header.tsx`\n\n**Elements:**\n- Settings button (gear icon, cyan background)\n- Upload Song button\n- Demo button\n- Song title/artist display (center)\n\n---\n\n#### 8. ChordDiagram\n**File:** `frontend/components/ChordDiagram.tsx`\n\n**Purpose:** Guitar chord visualization\n\n**Elements:**\n- Fretboard grid\n- Finger positions\n- Chord name label\n\n---\n\n### Component Hierarchy\n\n```\nApp (State Manager)\n├── Header\n│   ├── Settings Button → Opens SettingsPanel\n│   ├── Upload Button → Triggers upload flow\n│   └── Song Title (center)\n│\n├── Main Content (View-Switched)\n│   ├── TeleprompterView (Performance Mode)\n│   │   ├── Audio Controls Bar ✨ NEW\n│   │   │   ├── StemSelector ✨ NEW\n│   │   │   └── AudioPlayer ✨ NEW\n│   │   └── Lyrics Display (Living Chart)\n│   │\n│   ├── Full Chart (Edit Mode)\n│   └── SongMapDemo\n│\n├── Footer\n│\n└── SettingsPanel (Modal)\n    └── LibraryView\n```\n\n---\n\n## 📋 Feature Status\n\n### ✅ Complete (Sprint 1-2)\n\n| Feature | Component | Status |\n|---------|-----------|--------|\n| **Teleprompter display** | TeleprompterView | ✅ Complete |\n| **Syllable highlighting** | TeleprompterView | ✅ Complete |\n| **Auto-scroll** | TeleprompterView | ✅ Complete |\n| **Chord display** | TeleprompterView | ✅ Complete |\n| **Audio playback** | AudioPlayer | ✅ Complete |\n| **Stem selection** | StemSelector | ✅ Complete |\n| **Progress bar** | AudioPlayer | ✅ Complete |\n| **Volume control** | AudioPlayer | ✅ Complete |\n| **Song Map generation** | Backend | ✅ Complete |\n| **Library management** | LibraryView | ✅ Complete |\n| **Settings panel** | SettingsPanel | ✅ Complete |\n| **Full Chart editor** | BlueprintView | ✅ Complete |\n\n### 🔨 In Progress\n\n| Feature | Target | Current | Sprint |\n|---------|--------|---------|--------|\n| **60fps rendering** | 60fps | 50fps | Sprint 3 |\n| **Settings speed** | <2s | ~4s | Sprint 3 |\n\n### 📋 Planned\n\n#### Sprint 3 (Oct 8-21): Performance & Accessibility\n- [ ] 60fps rendering optimization\n- [ ] Auto-center active line (50% viewport)\n- [ ] Keyboard navigation (8 shortcuts)\n- [ ] ARIA labels and semantic HTML\n- [ ] High contrast mode\n- [ ] Focus indicators\n- [ ] Reduced motion mode\n\n#### Sprint 4 (Oct 22 - Nov 4): Enhanced Editing + SongPrep Experimentation\n- [ ] Chord autocomplete popup\n- [ ] Drag-to-reorder sections\n- [ ] Real-time chord validation\n- [ ] Emergency font adjust (double-tap)\n- [ ] Library autocomplete search\n- [ ] Settings presets\n- [ ] **SongPrep Integration Research** (NEW)\n  - [ ] Clone SongPrep repository and set up environment\n  - [ ] Download 7B model weights from HuggingFace\n  - [ ] Test on 10 sample songs\n  - [ ] Benchmark inference speed and accuracy\n  - [ ] Compare section detection vs current heuristics\n  - [ ] Assess GPU requirements and resource impact\n  - [ ] Document findings and integration recommendations\n\n#### Sprint 5 (Nov 5-18): Polish & Testing + SongPrep Integration\n- [ ] Micro-interactions and animations\n- [ ] Loading states (skeleton screens)\n- [ ] User testing\n- [ ] Bug fixes and polish\n- [ ] **SongPrep Integration** (if Sprint 4 experiments successful)\n  - [ ] Create `backend/src/services/songprep/` module\n  - [ ] Implement parser for SongPrep output → Song Map format\n  - [ ] Update orchestrator for parallel processing\n  - [ ] Add confidence scoring to sections\n  - [ ] E2E testing: Audio → SongPrep → Living Chart\n  - [ ] Performance optimization (GPU, caching)\n\n### 🔮 Future (Post-MVP)\n\n- **Phase 2 (Q1 2026):** Setlist management, mobile support, SongPrep fine-tuning\n- **Phase 3 (Q2 2026):** Collaborative editing, cloud sync, genre-specific structure models\n- **Phase 4 (Q3 2026):** AI accompaniment (drums, bass, keys)\n- **Phase 5 (Q4 2026):** Voice commands, custom training datasets\n\n---\n\n## 🗺️ Roadmap\n\n### MVP Timeline\n\n| Sprint | Dates | Theme | Deliverables |\n|--------|-------|-------|--------------|\n| **1-2** | ✅ Complete | Backend + Audio | Analysis pipeline, audio playback, stems |\n| **3** | Oct 8-21 | Performance + A11y | 60fps, keyboard nav, ARIA, high contrast |\n| **4** | Oct 22-Nov 4 | Enhanced Editing | Chord autocomplete, drag sections, emergency font |\n| **5** | Nov 5-18 | Polish + Testing | Animations, loading states, user testing |\n| **MVP** | Nov 22 | Launch | Feature complete, accessible, bug-free |\n\n### Sprint 3 Breakdown (Oct 8-21)\n\n**Week 1: Performance**\n1. Optimize TeleprompterView rendering (virtual scrolling)\n2. Add syllable pulse animation\n3. Implement auto-centering (50% viewport)\n\n**Week 2: Accessibility**\n1. Keyboard navigation (8 shortcuts)\n2. ARIA labels on all elements\n3. High contrast mode\n4. Focus indicators\n\n**Acceptance Criteria:**\n- [ ] 60fps sustained for 10-min song\n- [ ] All elements keyboard accessible\n- [ ] WCAG AAA contrast ratios\n- [ ] Lighthouse accessibility score: 95+\n\n---\n\n## 🔧 Developer Guide\n\n### Project Structure\n\n```\nPerformia/\n├── frontend/                  # React frontend\n│   ├── components/           # React components\n│   ├── services/             # Library service, etc.\n│   ├── hooks/                # Custom hooks\n│   ├── data/                 # Mock data\n│   ├── types.ts              # TypeScript definitions\n│   └── index.css             # Global styles\n│\n├── backend/                   # Python backend\n│   ├── src/\n│   │   ├── main.py           # FastAPI server\n│   │   ├── services/         # Audio analysis\n│   │   └── schemas/          # JSON schemas\n│   └── requirements.txt\n│\n└── PERFORMIA_MASTER_DOCS.md  # This file\n```\n\n### Development Workflow\n\n1. **Start Backend:**\n   ```bash\n   cd backend\n   python src/main.py\n   ```\n\n2. **Start Frontend:**\n   ```bash\n   cd frontend\n   npm run dev\n   ```\n\n3. **Make Changes:**\n   - Hot reload enabled (Vite)\n   - Backend restarts on file change\n\n4. **Test:**\n   ```bash\n   # Frontend\n   npm test\n\n   # Backend\n   pytest\n   ```\n\n5. **Commit:**\n   ```bash\n   git add .\n   git commit -m \"feat: description\"\n   git push\n   ```\n\n### Key Files to Know\n\n| File | Purpose |\n|------|---------|\n| `frontend/App.tsx` | Main app component, state management |\n| `frontend/components/TeleprompterView.tsx` | Living Chart display |\n| `frontend/components/AudioPlayer.tsx` | Audio playback controls |\n| `frontend/types.ts` | TypeScript type definitions |\n| `backend/src/main.py` | FastAPI server, routes |\n| `backend/schemas/song_map.schema.json` | Song Map structure |\n\n### Adding a New Component\n\n1. Create file in `frontend/components/`\n2. Define TypeScript interface for props\n3. Implement component with accessibility (ARIA labels)\n4. Add to parent component\n5. Update this documentation\n\n### Debugging Tips\n\n**Frontend:**\n- React DevTools for component tree\n- Console.log sparingly (use breakpoints)\n- Check Network tab for API calls\n\n**Backend:**\n- FastAPI auto-docs: `http://localhost:8000/docs`\n- Check logs for errors\n- Use Python debugger (pdb)\n\n**Performance:**\n- Chrome DevTools Performance tab\n- Target: 60fps (16.67ms per frame)\n- Check for layout thrashing\n\n---\n\n## ♿ Accessibility\n\n### WCAG Compliance\n\n**Target:** WCAG 2.1 AA minimum, AAA for critical elements\n\n### Contrast Ratios\n\n| Element | Ratio | Standard |\n|---------|-------|----------|\n| Lyrics | 16:1 | AAA |\n| Chords | 7:1 | AAA |\n| UI Controls | 4.5:1 | AA |\n\n### Keyboard Navigation\n\n| Key | Action | Context |\n|-----|--------|---------|\n| **Space** | Play/pause | Teleprompter |\n| **←/→** | Prev/next section | Teleprompter |\n| **Cmd+,** | Open settings | Global |\n| **Cmd+L** | Open library | Global |\n| **Cmd+E** | Toggle edit mode | Global |\n| **Esc** | Close modal | Global |\n| **Tab** | Navigate controls | Settings |\n| **Cmd+↑/↓** | Font size ±10% | Teleprompter |\n\n### Screen Reader Support\n\n- Semantic HTML (`<header>`, `<main>`, `<nav>`)\n- ARIA labels on all interactive elements\n- ARIA live regions for dynamic content\n- Announce section changes and playback state\n\n### Visual Accessibility\n\n- **High contrast mode** (black-on-white toggle)\n- **Focus indicators** (2px cyan outline)\n- **Reduced motion** (disable animations)\n- **Minimum touch targets** (44x44px)\n\n### Testing Checklist\n\n- [ ] Tab through all interactive elements\n- [ ] Test with screen reader (VoiceOver/NVDA)\n- [ ] Check contrast with WCAG Color Contrast Checker\n- [ ] Test reduced motion preference\n- [ ] Verify focus indicators visible\n\n---\n\n## 📊 Success Metrics\n\n### Quantitative Targets\n\n| Metric | Target | Current | Status |\n|--------|--------|---------|--------|\n| **Time to first performance** | <30s | ✅ 25s | ✅ Met |\n| **Song search speed** | <5s | ✅ 3s | ✅ Met |\n| **Settings adjust speed** | <2s | 🔨 4s | 🔨 In progress |\n| **Frame rate** | 60fps | 🔨 50fps | 🔨 In progress |\n| **Audio latency** | <50ms | ✅ 35ms | ✅ Met |\n| **Analysis speed** | <30s/song | ✅ 22s | ✅ Met |\n| **Chord accuracy** | 90%+ | ✅ 92% | ✅ Met |\n| **Lyric accuracy** | 95%+ | ✅ 96% | ✅ Met |\n\n### Qualitative Targets\n\n- **Ease of use:** 4.5+ stars (out of 5)\n- **Feature discovery:** 80%+ without tutorial\n- **Visual clarity:** 95%+ \"easy to read\"\n- **Performance satisfaction:** 90%+ \"feels instant\"\n\n### Analytics to Track\n\n1. Time to first performance\n2. Songs uploaded per user\n3. Most used features\n4. Error rate\n5. Session duration\n6. Return rate (weekly active)\n\n---\n\n## 🔍 Frequently Asked Questions\n\n### General\n\n**Q: What audio formats are supported?**\nA: WAV, MP3, M4A, FLAC\n\n**Q: How long does song analysis take?**\nA: ~30 seconds per song (varies by length)\n\n**Q: Can I edit the auto-generated chords?**\nA: Yes, use Full Chart to edit chords inline\n\n**Q: Does it work offline?**\nA: Not yet (planned for Phase 3)\n\n### Technical\n\n**Q: Why 60fps target?**\nA: Smooth scrolling is critical for reading during performance. 60fps = 16.67ms per frame.\n\n**Q: Canvas vs DOM for rendering?**\nA: Currently DOM. Will optimize first, consider Canvas only if needed (accessibility trade-off).\n\n**Q: How does syllable sync work?**\nA: RequestAnimationFrame checks current audio time, finds matching syllable, updates highlight.\n\n**Q: Why Performia cyan?**\nA: High contrast with warm amber chords, signals \"now\", cool color stands out.\n\n---\n\n## 📝 Contribution Guidelines\n\n### Code Style\n\n- **TypeScript:** Strict mode, explicit types\n- **React:** Functional components, hooks\n- **CSS:** Tailwind utility classes, avoid inline styles\n- **Naming:** camelCase for variables, PascalCase for components\n\n### Commit Messages\n\n```\nfeat: Add emergency font adjust gesture\nfix: Resolve audio sync latency issue\ndocs: Update component API reference\nrefactor: Optimize TeleprompterView rendering\ntest: Add unit tests for chord validation\n```\n\n### Pull Requests\n\n1. Create feature branch: `git checkout -b feat/my-feature`\n2. Make changes and commit\n3. Push: `git push -u origin feat/my-feature`\n4. Open PR with description\n5. Request review\n6. Merge after approval\n\n---\n\n## 🐛 Known Issues & Limitations\n\n### Current Limitations\n\n1. **Desktop only** (mobile support in Phase 2)\n2. **Local storage** (no cloud sync yet)\n3. **No collaboration** (single user editing)\n4. **English lyrics only** (multi-language in future)\n\n### Known Bugs\n\n*None currently tracked for MVP*\n\n### Workarounds\n\n**Issue:** Font size changes lag\n**Workaround:** Use preset sizes instead of slider\n\n**Issue:** Large songs (>10min) slow down\n**Workaround:** Virtual scrolling coming in Sprint 3\n\n---\n\n## 📚 Additional Resources\n\n### External Links\n\n- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)\n- [React Performance](https://react.dev/learn/render-and-commit)\n- [Tailwind CSS Docs](https://tailwindcss.com/docs)\n- [FastAPI Docs](https://fastapi.tiangolo.com/)\n- **[SongPrep Repository](https://github.com/tencent-ailab/SongPrep)** - Song structure parsing\n- **[SongPrep Paper](https://arxiv.org/abs/2509.17404)** - Technical details\n\n### Internal Files\n\n- `backend/schemas/song_map.schema.json` - Song Map structure\n- `frontend/types.ts` - TypeScript definitions\n- `.claude/CLAUDE.md` - Agent SDK instructions\n- **`docs/research/SONGPREP_ANALYSIS.md`** - SongPrep integration research\n\n---\n\n## 📅 Document History\n\n| Version | Date | Changes |\n|---------|------|---------|\n| 3.0 | Oct 1, 2025 | Consolidated all docs into master file |\n| 2.0 | Oct 1, 2025 | Added AudioPlayer & StemSelector specs |\n| 1.0 | Sep 30, 2025 | Initial documentation structure |\n\n---\n\n## 🎯 Core Principle\n\n> **\"The best interface for performance is no interface at all.\"**\n\nEvery decision must answer:\n**\"Does this help the musician perform better, or does it distract?\"**\n\nIf it distracts → Cut it.\nIf it helps → Polish it until it's invisible.\n\n---\n\n**Maintained by:** Performia Development Team\n**Next Review:** End of Sprint 3 (Oct 21, 2025)\n**Questions?** Check the FAQ or open an issue\n"
+}

--- a/ui/server/viztrtr-workspaces/proj_1759694167691_jbpwfbr/product-spec.json
+++ b/ui/server/viztrtr-workspaces/proj_1759694167691_jbpwfbr/product-spec.json
@@ -1,0 +1,591 @@
+{
+  "projectId": "proj_1759694167691_jbpwfbr",
+  "version": 1,
+  "createdAt": "2025-10-05T19:58:26.679Z",
+  "lastUpdated": "2025-10-05T19:58:26.679Z",
+  "productVision": "Performia is a revolutionary music performance system that transforms how musicians perform live by combining real-time audio analysis, AI-powered audio processing, and an intelligent Living Chart teleprompter, enabling musicians to focus on their artistry without forgetting lyrics or chords.",
+  "targetUsers": [
+    "Live performers (vocalists, guitarists, bands) who perform 3-4 gigs per week and need large fonts readable from 6ft away with zero distractions during performance",
+    "Rehearsal musicians learning new songs who need to edit chords and structure while practicing with isolated stems",
+    "Casual hobbyists practicing at home who need a simple, intuitive interface to explore demo songs"
+  ],
+  "components": {
+    "TeleprompterView": {
+      "purpose": "Fullscreen lyrics display with real-time syllable highlighting that follows the musician during performance",
+      "userStories": [
+        "As a live performer, I need lyrics that auto-scroll and highlight the current syllable so I never lose my place on stage",
+        "As a vocalist, I need chords displayed above lyrics in large fonts so I can see them from 6 feet away",
+        "As a musician, I need past lyrics dimmed and future lyrics bright so I can focus on what's coming next",
+        "As a performer, I need the active line centered in my viewport so I don't have to move my eyes"
+      ],
+      "designPriorities": [
+        "Maximum readability from 6ft distance",
+        "Zero-latency feel (<100ms interaction time)",
+        "Minimal visual distractions during performance",
+        "Smooth auto-scrolling at 60fps"
+      ],
+      "focusAreas": [
+        "Font size control (50%-150% range, default 3.5rem)",
+        "Syllable highlighting with cyan glow effect",
+        "Past lyrics opacity at 30%, future at 100%",
+        "Active line vertical centering at 50% viewport",
+        "Chord display positioning above lyrics",
+        "Auto-scroll smoothness and timing accuracy"
+      ],
+      "avoidAreas": [
+        "Complex animations that distract from lyrics",
+        "UI chrome visible during performance",
+        "Small touch targets or controls",
+        "Bright colors that cause eye strain"
+      ],
+      "acceptanceCriteria": [
+        "Sustained 60fps rendering for 10-minute songs",
+        "Active line auto-centers at 50% viewport height",
+        "Syllable highlight latency < 50ms from audio time",
+        "Font size range 2.5rem to 6.0rem with live preview",
+        "WCAG AAA contrast ratio (16:1) for lyrics text",
+        "Chord-to-lyric font ratio maintained at 80%"
+      ],
+      "status": "complete"
+    },
+    "AudioPlayer": {
+      "purpose": "Full-featured audio player with playback controls, progress bar, volume control, and real-time sync with lyrics",
+      "userStories": [
+        "As a performer, I need simple play/pause controls so I can quickly start and stop playback",
+        "As a musician, I need to seek to specific song positions so I can practice difficult sections",
+        "As a user, I need volume control so I can adjust playback to my environment",
+        "As a performer, I need to see current time and total duration so I know where I am in the song"
+      ],
+      "designPriorities": [
+        "Instant response to play/pause commands",
+        "Accurate time synchronization with lyrics",
+        "Clear visual feedback for all controls",
+        "Accessible from keyboard and touch"
+      ],
+      "focusAreas": [
+        "Play/pause button with clear icon states (▶ ⏸)",
+        "Draggable progress bar with cyan fill indicator",
+        "Volume slider (0.0-1.0) with mute button and icons",
+        "Time display in MM:SS format with monospace font",
+        "Real-time sync callbacks to parent components",
+        "Loading and buffering states"
+      ],
+      "avoidAreas": [
+        "Complex audio visualizations that slow rendering",
+        "Tiny slider handles or click targets",
+        "Auto-play without user consent",
+        "Volume changes without visual feedback"
+      ],
+      "acceptanceCriteria": [
+        "Play/pause responds within 100ms of click",
+        "Progress bar seek accurate to ±0.1 seconds",
+        "Volume slider range 0-100% with mute toggle",
+        "Time display updates at least 10 times per second",
+        "Touch targets minimum 44x44px for mobile",
+        "Keyboard controls (Space for play/pause, ←/→ for seek)"
+      ],
+      "status": "complete"
+    },
+    "StemSelector": {
+      "purpose": "Toggle between audio stems (vocals, drums, bass, other) to allow musicians to practice with isolated tracks",
+      "userStories": [
+        "As a vocalist, I need to isolate vocals so I can practice harmonies without distraction",
+        "As a guitarist, I need to mute guitars so I can practice my own parts",
+        "As a musician, I need to know when stems are loading so I understand system state",
+        "As a user, I need to see which stem is currently playing so I have clear feedback"
+      ],
+      "designPriorities": [
+        "Clear visual distinction between active and inactive stems",
+        "Fast switching between stems with minimal latency",
+        "Loading state visibility",
+        "Availability checking before display"
+      ],
+      "focusAreas": [
+        "5 stem types: Full Mix, Vocals, Bass, Drums, Other",
+        "Active state: cyan background, black text, scale 105%, play icon",
+        "Inactive state: gray-700 background, white text, hover gray-600",
+        "Loading state: 50% opacity, spinning clock icon",
+        "Unavailable state: 60% opacity, grayed out",
+        "HEAD request availability checking"
+      ],
+      "avoidAreas": [
+        "Automatic stem switching without user action",
+        "Confusing button labels or icons",
+        "Slow stem loading without feedback",
+        "Hidden or unclear active states"
+      ],
+      "acceptanceCriteria": [
+        "Stem switching completes within 2 seconds",
+        "Active stem visually distinct from inactive (clear cyan highlight)",
+        "Loading spinner visible during stem fetch",
+        "Unavailable stems clearly marked and unclickable",
+        "Keyboard navigation between stem buttons",
+        "Touch targets minimum 44x44px"
+      ],
+      "status": "complete"
+    },
+    "FullChart": {
+      "purpose": "Document-style editor for song structure, lyrics, and chords with inline editing capabilities",
+      "userStories": [
+        "As a musician, I need to edit chords inline so I can correct errors or adjust to my key",
+        "As a user, I need to edit lyrics so I can fix recognition mistakes",
+        "As a songwriter, I need to add and reorder sections so I can structure my song correctly",
+        "As a performer, I need to see all sections at once so I can plan my performance"
+      ],
+      "designPriorities": [
+        "Fast inline editing with click-to-edit",
+        "Clear visual hierarchy of sections",
+        "Non-destructive editing with undo capability",
+        "Immediate save and sync with teleprompter"
+      ],
+      "focusAreas": [
+        "Editable title, artist, key, BPM fields",
+        "Section headers (Verse, Chorus, Bridge, etc.)",
+        "Inline chord editing with autocomplete (planned Sprint 4)",
+        "Drag-to-reorder sections (planned Sprint 4)",
+        "Add/remove section buttons",
+        "Real-time chord validation"
+      ],
+      "avoidAreas": [
+        "Complex WYSIWYG editor features",
+        "Formatting options that distract from content",
+        "Slow save operations that block editing",
+        "Loss of work without autosave"
+      ],
+      "acceptanceCriteria": [
+        "Click any text element to edit in-place",
+        "Changes save within 1 second of blur event",
+        "Chord autocomplete appears within 200ms of typing",
+        "Drag section reordering with clear drop indicators",
+        "Undo/redo for last 20 actions",
+        "Keyboard shortcuts for common edits (Cmd+B for bold chord)"
+      ],
+      "status": "complete"
+    },
+    "LibraryView": {
+      "purpose": "Song search and library management interface for browsing, filtering, and organizing uploaded songs",
+      "userStories": [
+        "As a performer, I need to search songs by title or artist so I can quickly find what to perform",
+        "As a musician, I need to filter by key and genre so I can find songs that fit my setlist",
+        "As a user, I need to see song metadata at a glance so I can make quick decisions",
+        "As a performer, I need quick actions (Play, Edit, Delete) so I can manage my library efficiently"
+      ],
+      "designPriorities": [
+        "Fast search with instant results (<100ms)",
+        "Clear visual hierarchy of song cards",
+        "One-click actions for common tasks",
+        "Responsive grid layout"
+      ],
+      "focusAreas": [
+        "Instant search with fuzzy matching",
+        "Filter by genre, key, BPM, difficulty",
+        "Sort by title, date added, last played",
+        "Song card design with thumbnail, metadata",
+        "Quick action buttons on hover/focus",
+        "Empty state and loading states"
+      ],
+      "avoidAreas": [
+        "Slow database queries that block UI",
+        "Complex filter UI that requires multiple clicks",
+        "Hidden actions or nested menus",
+        "Pagination that slows browsing"
+      ],
+      "acceptanceCriteria": [
+        "Search results update within 100ms of keystroke",
+        "Filter application completes within 200ms",
+        "Song cards display all key metadata (title, artist, key, BPM)",
+        "Quick actions visible on hover and keyboard focus",
+        "Grid responsive to viewport width (1-4 columns)",
+        "Empty state with clear call-to-action to upload"
+      ],
+      "status": "complete"
+    },
+    "SettingsPanel": {
+      "purpose": "Quick access panel for performance controls including chord display, font size, transpose, and capo settings",
+      "userStories": [
+        "As a performer, I need to adjust font size quickly so I can optimize readability from my position",
+        "As a guitarist, I need to transpose and set capo so chords match my playing",
+        "As a musician, I need to toggle chord display modes so I can choose names or diagrams",
+        "As a user, I need settings to persist so I don't reconfigure every session"
+      ],
+      "designPriorities": [
+        "Fast settings changes (<2s target)",
+        "Live preview of changes",
+        "Clear labels and value indicators",
+        "Persistent settings across sessions"
+      ],
+      "focusAreas": [
+        "Chord display mode toggle (Off, Names, Diagrams)",
+        "Font size slider (50%-150%) with live preview",
+        "Transpose selector (-12 to +12 semitones)",
+        "Capo selector (0-12 frets)",
+        "Settings presets (planned Sprint 4)",
+        "High contrast mode toggle (planned Sprint 3)"
+      ],
+      "avoidAreas": [
+        "Settings changes that require page reload",
+        "Unclear labels or units",
+        "Slow slider response or laggy preview",
+        "Settings that don't persist"
+      ],
+      "acceptanceCriteria": [
+        "Font size changes apply within 100ms",
+        "Transpose and capo update chords instantly",
+        "Chord display mode switches without flicker",
+        "Settings persist to localStorage on change",
+        "Settings panel opens/closes within 200ms",
+        "Keyboard shortcuts for common settings (Cmd+↑/↓ for font)"
+      ],
+      "status": "complete"
+    },
+    "Header": {
+      "purpose": "Top navigation bar with settings access, upload functionality, demo button, and current song display",
+      "userStories": [
+        "As a user, I need quick access to settings so I can adjust performance options",
+        "As a musician, I need an upload button so I can add new songs easily",
+        "As a new user, I need a demo button so I can try the app without uploading",
+        "As a performer, I need to see the current song title so I know what's loaded"
+      ],
+      "designPriorities": [
+        "Always visible navigation",
+        "Clear action hierarchy",
+        "Current context visibility",
+        "Fast access to key functions"
+      ],
+      "focusAreas": [
+        "Settings button (gear icon, cyan background) on left",
+        "Upload Song button with clear label",
+        "Demo button for first-time users",
+        "Song title and artist centered",
+        "Responsive layout for mobile",
+        "Keyboard focus indicators"
+      ],
+      "avoidAreas": [
+        "Hidden menus that require discovery",
+        "Small touch targets",
+        "Unclear button labels or icons only",
+        "Blocking modals without escape"
+      ],
+      "acceptanceCriteria": [
+        "Header height 60-80px for adequate touch targets",
+        "Settings button opens panel within 200ms",
+        "Upload button triggers file picker immediately",
+        "Demo button loads sample song within 500ms",
+        "Song title truncates gracefully on narrow screens",
+        "All buttons keyboard accessible with Tab navigation"
+      ],
+      "status": "complete"
+    },
+    "ChordDiagram": {
+      "purpose": "Visual guitar chord diagram showing finger positions on fretboard",
+      "userStories": [
+        "As a guitarist, I need to see chord fingerings so I can play unfamiliar chords",
+        "As a beginner, I need clear visual diagrams so I understand where to place my fingers",
+        "As a performer, I need diagrams large enough to see from performing distance"
+      ],
+      "designPriorities": [
+        "Clear fretboard visualization",
+        "Accurate finger position markers",
+        "High contrast for stage visibility",
+        "Compact size that doesn't obscure lyrics"
+      ],
+      "focusAreas": [
+        "Fretboard grid with 6 strings and 4-5 frets",
+        "Finger position dots with numbers (1-4)",
+        "Open string indicators (O) and muted strings (X)",
+        "Chord name label above diagram",
+        "Scalable SVG for crisp rendering",
+        "Consistent sizing with lyric font scale"
+      ],
+      "avoidAreas": [
+        "Complex notation that slows comprehension",
+        "Tiny diagrams that are unreadable from distance",
+        "Cluttered layouts with too much information",
+        "Raster images that pixelate when scaled"
+      ],
+      "acceptanceCriteria": [
+        "Diagrams render as vector graphics (SVG)",
+        "Finger positions clearly marked with contrast ratio > 7:1",
+        "Diagram size scales with font size setting",
+        "Chord name legible and positioned consistently",
+        "Renders within 50ms of chord change",
+        "Falls back gracefully for unknown chords"
+      ],
+      "status": "complete"
+    },
+    "UploadFlow": {
+      "purpose": "Multi-step upload and analysis process with progress tracking and error handling",
+      "userStories": [
+        "As a musician, I need to upload audio files easily so I can add new songs to my library",
+        "As a user, I need to see analysis progress so I know how long to wait",
+        "As a performer, I need error messages so I understand what went wrong",
+        "As a user, I need to cancel uploads so I can fix mistakes"
+      ],
+      "designPriorities": [
+        "Clear progress indication",
+        "Helpful error messages",
+        "Fast upload and processing",
+        "Cancellable operations"
+      ],
+      "focusAreas": [
+        "Drag-and-drop file upload zone",
+        "File type validation (WAV, MP3, M4A, FLAC)",
+        "Progress bar with percentage and status text",
+        "Analysis stages: Upload, Stem Separation, Lyrics, Chords, Structure",
+        "Error states with retry button",
+        "Cancel button during processing",
+        "Success state with auto-redirect to song"
+      ],
+      "avoidAreas": [
+        "Silent failures without error messages",
+        "Progress bars that jump or freeze",
+        "Uploads that block the entire UI",
+        "Unclear error messages like 'Error 500'"
+      ],
+      "acceptanceCriteria": [
+        "Upload completes within 30 seconds for typical 3-minute song",
+        "Progress updates at least every 2 seconds",
+        "File validation shows clear error for unsupported formats",
+        "Cancel button stops processing and cleans up resources",
+        "Success state displays for 2 seconds before redirect",
+        "Error messages include actionable next steps"
+      ],
+      "status": "complete"
+    },
+    "AudioControlsBar": {
+      "purpose": "Unified control bar combining audio player and stem selector for performance mode",
+      "userStories": [
+        "As a performer, I need all audio controls in one place so I can control playback without searching",
+        "As a musician, I need controls visible but not distracting so they don't interfere with reading lyrics",
+        "As a user, I need controls that auto-hide so they disappear during performance"
+      ],
+      "designPriorities": [
+        "Consolidated control layout",
+        "Minimal visual footprint",
+        "Fast access when needed",
+        "Auto-hide during performance"
+      ],
+      "focusAreas": [
+        "Fixed position bar at top of teleprompter view",
+        "Height 120-180px to accommodate controls",
+        "Gray-800 background with subtle opacity",
+        "StemSelector and AudioPlayer side-by-side layout",
+        "Responsive stacking on narrow screens",
+        "Optional auto-hide after 5 seconds of inactivity"
+      ],
+      "avoidAreas": [
+        "Controls that obstruct lyrics when active",
+        "Animations that distract during performance",
+        "Complex nested menus",
+        "Controls that are hard to reactivate when hidden"
+      ],
+      "acceptanceCriteria": [
+        "Bar height fixed at 120-180px for consistent layout",
+        "Controls remain accessible with mouse movement or tap",
+        "Auto-hide triggers after 5 seconds without interaction",
+        "Re-show on mouse move to top 200px of viewport",
+        "All controls keyboard accessible when visible",
+        "Smooth fade transition (300ms) on hide/show"
+      ],
+      "status": "complete"
+    },
+    "EmergencyFontAdjust": {
+      "purpose": "Quick gesture-based font size adjustment for emergency situations during performance",
+      "userStories": [
+        "As a performer, I need to adjust font size mid-performance so I can adapt to stage lighting or distance changes",
+        "As a musician, I need a gesture that won't disrupt playback so I can adjust without stopping the song"
+      ],
+      "designPriorities": [
+        "Instant response to gesture",
+        "No interference with performance",
+        "Clear visual feedback",
+        "Easy to trigger without looking"
+      ],
+      "focusAreas": [
+        "Double-tap anywhere to open quick adjust popup",
+        "Large +/- buttons (80x80px minimum)",
+        "10% increment/decrement per tap",
+        "Popup auto-dismisses after 3 seconds",
+        "Keyboard shortcuts Cmd+↑/↓ as alternative",
+        "Visual feedback of current size percentage"
+      ],
+      "avoidAreas": [
+        "Gestures that conflict with scrolling or seeking",
+        "Small buttons that are hard to tap in stress",
+        "Persistent UI that blocks lyrics",
+        "Complex multi-touch gestures"
+      ],
+      "acceptanceCriteria": [
+        "Double-tap detected within 300ms",
+        "Popup appears within 100ms of gesture",
+        "Font change applies immediately on +/- tap",
+        "Popup dismisses after 3 seconds or on outside tap",
+        "Buttons minimum 80x80px for easy emergency tapping",
+        "Keyboard shortcuts work when popup not visible"
+      ],
+      "status": "planned"
+    },
+    "KeyboardNavigation": {
+      "purpose": "Comprehensive keyboard shortcuts for power users and accessibility",
+      "userStories": [
+        "As a power user, I need keyboard shortcuts so I can control the app without a mouse",
+        "As a performer with limited mobility, I need keyboard access so I can use the app independently",
+        "As a user, I need discoverable shortcuts so I can learn them over time"
+      ],
+      "designPriorities": [
+        "Complete keyboard accessibility",
+        "Intuitive shortcut mappings",
+        "Discoverability without documentation",
+        "No conflicts with browser shortcuts"
+      ],
+      "focusAreas": [
+        "8 core shortcuts: Space (play/pause), ←/→ (prev/next section), Cmd+, (settings), Cmd+L (library), Cmd+E (edit mode), Esc (close modal), Cmd+↑/↓ (font adjust)",
+        "Tab navigation through all interactive elements",
+        "Focus indicators (2px cyan outline)",
+        "Shortcut help panel accessible with ?",
+        "Shortcuts work in all views",
+        "No keyboard traps"
+      ],
+      "avoidAreas": [
+        "Shortcuts that conflict with browser (Cmd+T, Cmd+W)",
+        "Complex multi-key combinations",
+        "Hidden shortcuts without discoverability",
+        "Shortcuts that don't work consistently"
+      ],
+      "acceptanceCriteria": [
+        "All 8 core shortcuts respond within 100ms",
+        "Tab order logical and complete through UI",
+        "Focus indicators visible on all focusable elements",
+        "? key opens shortcut help panel",
+        "Esc closes any open modal or panel",
+        "No keyboard traps (can always navigate away)"
+      ],
+      "status": "planned"
+    },
+    "HighContrastMode": {
+      "purpose": "Accessibility mode with maximum contrast for users with visual impairments or bright stage lighting",
+      "userStories": [
+        "As a user with low vision, I need high contrast mode so I can read lyrics clearly",
+        "As a performer under bright lights, I need maximum contrast so glare doesn't wash out text",
+        "As a user, I need to toggle contrast quickly so I can adapt to different environments"
+      ],
+      "designPriorities": [
+        "WCAG AAA compliance (7:1 minimum)",
+        "No loss of functionality",
+        "Clear toggle in settings",
+        "Instant mode switching"
+      ],
+      "focusAreas": [
+        "Black-on-white color scheme for lyrics",
+        "Inverted UI chrome colors",
+        "Thicker focus indicators (3px)",
+        "Increased border weights",
+        "Removal of subtle shadows",
+        "Toggle in settings panel",
+        "Preference persistence"
+      ],
+      "avoidAreas": [
+        "Low contrast decorative elements",
+        "Color-only information indicators",
+        "Subtle hover states that disappear",
+        "Theme switching that requires reload"
+      ],
+      "acceptanceCriteria": [
+        "All text meets WCAG AAA 7:1 contrast ratio",
+        "Toggle switches mode within 100ms",
+        "No functionality lost in high contrast mode",
+        "Mode preference persists across sessions",
+        "Focus indicators visible against all backgrounds",
+        "Works with system high contrast preferences"
+      ],
+      "status": "planned"
+    },
+    "ReducedMotionMode": {
+      "purpose": "Accessibility mode that reduces or eliminates animations for users sensitive to motion",
+      "userStories": [
+        "As a user with vestibular disorders, I need reduced motion so the app doesn't cause discomfort",
+        "As a performer, I need to disable distracting animations so I can focus on lyrics"
+      ],
+      "designPriorities": [
+        "Respect prefers-reduced-motion CSS media query",
+        "No loss of information or functionality",
+        "Instant transitions instead of animations",
+        "Clear visual feedback remains"
+      ],
+      "focusAreas": [
+        "Auto-detect prefers-reduced-motion system preference",
+        "Manual toggle in settings panel",
+        "Disable syllable pulse animations",
+        "Replace slide/fade with instant show/hide",
+        "Keep position-based scrolling (essential function)",
+        "Maintain highlighting without animation"
+      ],
+      "avoidAreas": [
+        "Removing feedback entirely",
+        "Jarring instant changes without preparation",
+        "Ignoring system accessibility preferences",
+        "Making reduced motion opt-in only"
+      ],
+      "acceptanceCriteria": [
+        "Auto-enables when prefers-reduced-motion detected",
+        "Manual toggle available in settings",
+        "All non-essential animations disabled",
+        "Scrolling remains smooth (essential for readability)",
+        "Visual feedback remains clear without motion",
+        "Mode preference persists across sessions"
+      ],
+      "status": "planned"
+    }
+  },
+  "globalConstraints": {
+    "accessibility": [
+      "WCAG 2.1 AA minimum compliance, AAA for critical elements",
+      "Minimum contrast ratio 4.5:1 for UI controls, 7:1 for chords, 16:1 for lyrics",
+      "All interactive elements keyboard accessible",
+      "ARIA labels on all components",
+      "Semantic HTML structure",
+      "Screen reader support (VoiceOver, NVDA)",
+      "Focus indicators visible on all focusable elements (2px cyan outline)",
+      "Minimum touch target size 44x44px",
+      "High contrast mode available",
+      "Reduced motion mode respects system preferences"
+    ],
+    "performance": [
+      "60fps sustained rendering (16.67ms per frame)",
+      "Perceived interaction time < 100ms",
+      "Audio latency < 50ms",
+      "Settings changes apply < 2 seconds",
+      "Song search results < 100ms",
+      "Upload and analysis < 30 seconds per song",
+      "Font size changes < 100ms",
+      "Auto-scroll smoothness at 60fps",
+      "No layout thrashing or reflows during playback"
+    ],
+    "browser": [
+      "Chrome 90+",
+      "Safari 14+",
+      "Firefox 88+",
+      "Edge 90+",
+      "Desktop only for MVP (mobile support Phase 2)",
+      "Minimum viewport 1024x768",
+      "Optimized for 1920x1080 and larger displays"
+    ],
+    "design": [
+      "Performance-first: UI disappears during performance",
+      "Zero-latency feel: < 100ms perceived interaction time",
+      "Musician mental model: sections, keys, chords",
+      "Progressive disclosure: complexity hidden until needed",
+      "Accessibility by default: works for all musicians",
+      "Performia cyan (#06b6d4) as primary accent color",
+      "Near-black background (rgb(10,10,12)) for stage use",
+      "Cool white text (rgb(240,240,245)) for maximum legibility",
+      "Warm amber (#FACC15) for inactive chords (WCAG AAA)",
+      "Typography scale: 3.5rem default lyrics, 2.8rem chords (80% ratio)",
+      "Tailwind CSS 4 utility-first styling",
+      "Consistent spacing system (4px base unit)",
+      "Smooth transitions (300ms default)",
+      "Material Design 3 influence for controls"
+    ]
+  },
+  "originalPRD": "# 🎵 Performia - Complete Documentation\n\n**Version:** 3.0\n**Last Updated:** October 1, 2025\n**Status:** Living Document\n\n---\n\n## 📖 Table of Contents\n\n### Quick Navigation\n- [🎯 Product Overview](#-product-overview)\n- [🚀 Quick Start](#-quick-start)\n- [🏗️ Architecture](#️-architecture)\n- [🎨 Design System](#-design-system)\n- [🧩 Component Library](#-component-library)\n- [📋 Feature Status](#-feature-status)\n- [🗺️ Roadmap](#️-roadmap)\n- [🔧 Developer Guide](#-developer-guide)\n- [♿ Accessibility](#-accessibility)\n- [📊 Success Metrics](#-success-metrics)\n\n---\n\n## 🎯 Product Overview\n\n### What is Performia?\n\n**Performia** is a revolutionary music performance system that transforms how musicians perform live. By combining real-time audio analysis, AI-powered audio processing, and an intelligent \"Living Chart\" teleprompter, Performia enables musicians to focus on their artistry.\n\n**Core Value Proposition:**\n*\"Never forget lyrics or chords again. Performia follows YOU in real-time.\"*\n\n### Target Users\n\n1. **Live Performers** (Primary)\n   - Vocalists, guitarists, bands\n   - Perform 3-4 gigs per week\n   - Need large fonts readable from 6ft away\n   - Zero distractions during performance\n\n2. **Rehearsal Musicians** (Secondary)\n   - Learning new songs\n   - Need to edit chords and structure\n   - Practice with isolated stems\n\n3. **Casual Hobbyists** (Tertiary)\n   - Home practice\n   - Need simple, intuitive interface\n   - Explore demo songs\n\n### Design Philosophy\n\n> **\"The best interface for performance is no interface at all.\"**\n\n**Core Principles:**\n1. **Performance-First**: UI disappears during performance\n2. **Zero-Latency Feel**: <100ms perceived interaction time\n3. **Musician Mental Model**: Sections, keys, chords\n4. **Progressive Disclosure**: Complexity hidden until needed\n5. **Accessibility by Default**: Works for all musicians\n\n---\n\n## 🚀 Quick Start\n\n### Running Performia\n\n#### Backend (Python + C++)\n```bash\ncd backend\npython -m venv venv\nsource venv/bin/activate  # On Windows: venv\\Scripts\\activate\npip install -r requirements.txt\npython src/main.py\n```\n\nBackend runs on: `http://localhost:8000`\n\n#### Frontend (React + Vite)\n```bash\ncd frontend\nnpm install\nnpm run dev\n```\n\nFrontend runs on: `http://localhost:5001`\n\n### First-Time User Flow\n\n1. **Open Performia** → Demo song \"Yesterday\" loads automatically\n2. **Click Settings** (gear icon) → Adjust font size, transpose\n3. **Click Play** → Watch syllables highlight in real-time\n4. **Upload Song** → Drop audio file, wait ~30s for analysis\n5. **Perform** → Fullscreen lyrics with chords, zero distractions\n\n---\n\n## 🏗️ Architecture\n\n### Tech Stack\n\n**Frontend:**\n- React 19 + TypeScript 5\n- Vite 6 (build tool)\n- Tailwind CSS 4 (styling)\n- React hooks (state management)\n\n**Backend:**\n- Python 3.11 + FastAPI\n- JUCE (C++ audio engine)\n- Librosa (audio analysis)\n- Demucs (stem separation)\n- Whisper (speech recognition / ASR)\n- **SongPrep** (planned - song structure parsing)\n\n### Data Flow\n\n```\n1. Upload Audio → Backend\n2. Analysis Pipeline → Song Map JSON\n3. Frontend → Display Living Chart\n4. Audio Playback → Syllable Sync\n```\n\n### Song Map Schema\n\n```json\n{\n  \"title\": \"Song Title\",\n  \"artist\": \"Artist Name\",\n  \"key\": \"C Major\",\n  \"bpm\": 120,\n  \"sections\": [\n    {\n      \"name\": \"Verse 1\",\n      \"lines\": [\n        {\n          \"syllables\": [\n            {\n              \"text\": \"Hello\",\n              \"startTime\": 0.5,\n              \"duration\": 0.3,\n              \"chord\": \"C\"\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}\n```\n\n### API Endpoints\n\n| Endpoint | Method | Purpose |\n|----------|--------|---------|\n| `/upload` | POST | Upload audio file |\n| `/progress/:jobId` | GET | Analysis progress |\n| `/songmap/:jobId` | GET | Get Song Map JSON |\n| `/audio/:jobId/original` | GET | Get original audio |\n| `/audio/:jobId/stem/:type` | GET | Get stem (vocals, bass, drums, other) |\n\n---\n\n## 🎨 Design System\n\n### Color Palette\n\n#### Performance Mode (Stage)\n```css\n--bg-performance: rgb(10, 10, 12)      /* Near-black, minimal glare */\n--text-lyrics: rgb(240, 240, 245)      /* Cool white, max legibility */\n--chord-inactive: #FACC15              /* Warm amber (WCAG AAA) */\n--chord-active: #06b6d4                /* Performia cyan */\n--highlight-sung: rgba(6, 182, 212, 0.3)  /* Cyan glow */\n```\n\n#### UI Chrome (Controls)\n```css\n--bg-chrome: #111827                   /* Gray-900 */\n--bg-panel: #1f2937                    /* Gray-800 */\n--bg-input: #374151                    /* Gray-700 */\n--accent-primary: #06b6d4              /* Performia cyan */\n--accent-hover: #06d4f1                /* Lighter cyan */\n--accent-success: #22c55e              /* Green */\n--accent-warning: #eab308              /* Yellow */\n--accent-error: #ef4444                /* Red */\n```\n\n### Typography Scale\n\n```css\n/* Teleprompter (Performance) */\n--font-lyrics-default: 3.5rem   /* 56px - Stage optimized */\n--font-lyrics-min: 2.5rem       /* 40px */\n--font-lyrics-max: 6.0rem       /* 96px */\n--font-chord: 2.8rem            /* 45px - 80% ratio maintained */\n\n/* UI Chrome */\n--font-header-1: 2.5rem         /* Song title */\n--font-header-2: 1.875rem       /* Artist */\n--font-body: 1.125rem           /* Editable text */\n--font-control: 1rem            /* Buttons */\n--font-label: 0.875rem          /* Labels */\n--font-caption: 0.75rem         /* Metadata */\n```\n\n### Spacing System\n\n```css\n--space-xs:   4px\n--space-sm:   8px\n--space-md:   16px\n--space-lg:   24px\n--space-xl:   32px\n--space-2xl:  48px\n```\n\n### Border Radius\n\n```css\n--radius-sm:  4px\n--radius-md:  8px\n--radius-lg:  12px\n--radius-xl:  16px\n--radius-full: 9999px  /* Pill shape */\n```\n\n### Shadows\n\n```css\n--shadow-sm: 0 1px 2px rgba(0,0,0,0.05)\n--shadow-md: 0 4px 6px rgba(0,0,0,0.1)\n--shadow-lg: 0 10px 15px rgba(0,0,0,0.1)\n--shadow-xl: 0 20px 25px rgba(0,0,0,0.1)\n--shadow-cyan: 0 10px 15px rgba(6,182,212,0.2)\n```\n\n---\n\n## 🧩 Component Library\n\n### Core Components\n\n#### 1. TeleprompterView (Living Chart)\n**File:** `frontend/components/TeleprompterView.tsx`\n\n**Purpose:** Fullscreen lyrics with real-time syllable highlighting\n\n**Features:**\n- Real-time syllable highlighting\n- Auto-scroll (active line centered)\n- Chord display (names or diagrams)\n- Audio controls integration\n- Font size control (50%-150%)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│ [Audio Controls Bar]                │  ← 120-180px height\n├─────────────────────────────────────┤\n│                                     │\n│    Past lyrics (30% opacity)        │\n│                                     │\n│  ╔═══════════════════════════════╗ │\n│  ║   C              G            ║ │  ← Active line\n│  ║   Here comes the sun ◆ doo   ║ │  ← ◆ = current syllable\n│  ╚═══════════════════════════════╝ │\n│                                     │\n│    Future lyrics (100% opacity)     │\n│                                     │\n└─────────────────────────────────────┘\n```\n\n**Props:**\n```typescript\ninterface TeleprompterViewProps {\n  songMap: SongMap;\n  transpose: number;\n  capo: number;\n  chordDisplay: 'off' | 'names' | 'diagrams';\n  jobId?: string;\n}\n```\n\n---\n\n#### 2. AudioPlayer ✨ NEW\n**File:** `frontend/components/AudioPlayer.tsx`\n\n**Purpose:** Full-featured audio player with playback controls\n\n**Features:**\n- Play/pause button\n- Progress bar (draggable seek)\n- Volume control (slider + mute)\n- Time display (MM:SS / MM:SS)\n- Real-time sync with lyrics\n\n**UI Elements:**\n- **Progress Bar:** Cyan fill, gray background, draggable\n- **Play/Pause:** Cyan button, black text, icons ▶ ⏸\n- **Volume:** Slider (0.0-1.0), mute button 🔇 🔉 🔊\n- **Time:** Monospace font, white text\n\n**Container:** Gray-800 background, 16px padding, 8px radius\n\n**Props:**\n```typescript\ninterface AudioPlayerProps {\n  audioUrl: string;\n  onTimeUpdate: (currentTime: number) => void;\n  onDurationChange?: (duration: number) => void;\n  onPlayStateChange?: (isPlaying: boolean) => void;\n}\n```\n\n---\n\n#### 3. StemSelector ✨ NEW\n**File:** `frontend/components/StemSelector.tsx`\n\n**Purpose:** Toggle between audio stems (vocals, drums, bass, etc.)\n\n**Features:**\n- 5 stem types: Full Mix, Vocals, Bass, Drums, Other\n- Loading states (spinner icon)\n- Availability check (HEAD request)\n- Active state highlighting\n\n**Button States:**\n- **Selected:** Cyan background, black text, scale 105%, play icon ▶\n- **Unselected:** Gray-700 background, white text, hover gray-600\n- **Loading:** 50% opacity, spinning clock ⌛\n- **Unavailable:** 60% opacity, grayed out\n\n**Props:**\n```typescript\ninterface StemSelectorProps {\n  jobId: string;\n  baseUrl?: string;\n  onStemChange: (stemUrl: string, stemType: StemType) => void;\n}\n\ntype StemType = 'original' | 'vocals' | 'bass' | 'drums' | 'other';\n```\n\n---\n\n#### 4. Full Chart (Song Editor)\n**File:** `frontend/components/BlueprintView.tsx`\n\n**Purpose:** Document-style editor for song structure and chords\n\n**Features:**\n- Inline editing (click to edit)\n- Edit title, artist, lyrics, chords\n- Section headers (Verse, Chorus, etc.)\n- Chord autocomplete (planned Sprint 4)\n- Drag-to-reorder sections (planned Sprint 4)\n\n**Layout:**\n```\n┌─────────────────────────────────────┐\n│  Song Title (editable)              │\n│  Artist Name (editable)             │\n│  Key: C Major | BPM: 120            │\n├─────────────────────────────────────┤\n│  ┌─ [ Verse 1 ] ─────────────────┐ │\n│  │  C            G                │ │\n│  │  Here comes the sun           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  ┌─ [ Chorus ] ──────── [⋮] ─────┐ │  ← Drag handle\n│  │  ...                           │ │\n│  └────────────────────────────────┘ │\n│                                     │\n│  [+ Add Section]                    │\n└─────────────────────────────────────┘\n```\n\n---\n\n#### 5. LibraryView\n**File:** `frontend/components/LibraryView.tsx`\n\n**Purpose:** Song search and library management\n\n**Features:**\n- Instant search (title, artist, lyrics, tags)\n- Filter by genre, key, BPM, difficulty\n- Sort by title, date added, last played\n- Quick actions: Play, Edit, Delete\n- Song cards with metadata\n\n**Search:** Fuzzy matching, autocomplete (planned Sprint 4)\n\n---\n\n#### 6. SettingsPanel\n**File:** `frontend/components/SettingsPanel.tsx`\n\n**Purpose:** Quick access to performance controls\n\n**Features:**\n- Chord display mode (Off, Names, Diagrams)\n- Font size slider (50%-150%)\n- Transpose (-12 to +12)\n- Capo (0-12 frets)\n- Settings presets (planned Sprint 4)\n- High contrast mode (planned Sprint 3)\n\n**Layout:** Slide-in from left, 384px width\n\n---\n\n#### 7. Header\n**File:** `frontend/components/Header.tsx`\n\n**Elements:**\n- Settings button (gear icon, cyan background)\n- Upload Song button\n- Demo button\n- Song title/artist display (center)\n\n---\n\n#### 8. ChordDiagram\n**File:** `frontend/components/ChordDiagram.tsx`\n\n**Purpose:** Guitar chord visualization\n\n**Elements:**\n- Fretboard grid\n- Finger positions\n- Chord name label\n\n---\n\n### Component Hierarchy\n\n```\nApp (State Manager)\n├── Header\n│   ├── Settings Button → Opens SettingsPanel\n│   ├── Upload Button → Triggers upload flow\n│   └── Song Title (center)\n│\n├── Main Content (View-Switched)\n│   ├── TeleprompterView (Performance Mode)\n│   │   ├── Audio Controls Bar ✨ NEW\n│   │   │   ├── StemSelector ✨ NEW\n│   │   │   └── AudioPlayer ✨ NEW\n│   │   └── Lyrics Display (Living Chart)\n│   │\n│   ├── Full Chart (Edit Mode)\n│   └── SongMapDemo\n│\n├── Footer\n│\n└── SettingsPanel (Modal)\n    └── LibraryView\n```\n\n---\n\n## 📋 Feature Status\n\n### ✅ Complete (Sprint 1-2)\n\n| Feature | Component | Status |\n|---------|-----------|--------|\n| **Teleprompter display** | TeleprompterView | ✅ Complete |\n| **Syllable highlighting** | TeleprompterView | ✅ Complete |\n| **Auto-scroll** | TeleprompterView | ✅ Complete |\n| **Chord display** | TeleprompterView | ✅ Complete |\n| **Audio playback** | AudioPlayer | ✅ Complete |\n| **Stem selection** | StemSelector | ✅ Complete |\n| **Progress bar** | AudioPlayer | ✅ Complete |\n| **Volume control** | AudioPlayer | ✅ Complete |\n| **Song Map generation** | Backend | ✅ Complete |\n| **Library management** | LibraryView | ✅ Complete |\n| **Settings panel** | SettingsPanel | ✅ Complete |\n| **Full Chart editor** | BlueprintView | ✅ Complete |\n\n### 🔨 In Progress\n\n| Feature | Target | Current | Sprint |\n|---------|--------|---------|--------|\n| **60fps rendering** | 60fps | 50fps | Sprint 3 |\n| **Settings speed** | <2s | ~4s | Sprint 3 |\n\n### 📋 Planned\n\n#### Sprint 3 (Oct 8-21): Performance & Accessibility\n- [ ] 60fps rendering optimization\n- [ ] Auto-center active line (50% viewport)\n- [ ] Keyboard navigation (8 shortcuts)\n- [ ] ARIA labels and semantic HTML\n- [ ] High contrast mode\n- [ ] Focus indicators\n- [ ] Reduced motion mode\n\n#### Sprint 4 (Oct 22 - Nov 4): Enhanced Editing + SongPrep Experimentation\n- [ ] Chord autocomplete popup\n- [ ] Drag-to-reorder sections\n- [ ] Real-time chord validation\n- [ ] Emergency font adjust (double-tap)\n- [ ] Library autocomplete search\n- [ ] Settings presets\n- [ ] **SongPrep Integration Research** (NEW)\n  - [ ] Clone SongPrep repository and set up environment\n  - [ ] Download 7B model weights from HuggingFace\n  - [ ] Test on 10 sample songs\n  - [ ] Benchmark inference speed and accuracy\n  - [ ] Compare section detection vs current heuristics\n  - [ ] Assess GPU requirements and resource impact\n  - [ ] Document findings and integration recommendations\n\n#### Sprint 5 (Nov 5-18): Polish & Testing + SongPrep Integration\n- [ ] Micro-interactions and animations\n- [ ] Loading states (skeleton screens)\n- [ ] User testing\n- [ ] Bug fixes and polish\n- [ ] **SongPrep Integration** (if Sprint 4 experiments successful)\n  - [ ] Create `backend/src/services/songprep/` module\n  - [ ] Implement parser for SongPrep output → Song Map format\n  - [ ] Update orchestrator for parallel processing\n  - [ ] Add confidence scoring to sections\n  - [ ] E2E testing: Audio → SongPrep → Living Chart\n  - [ ] Performance optimization (GPU, caching)\n\n### 🔮 Future (Post-MVP)\n\n- **Phase 2 (Q1 2026):** Setlist management, mobile support, SongPrep fine-tuning\n- **Phase 3 (Q2 2026):** Collaborative editing, cloud sync, genre-specific structure models\n- **Phase 4 (Q3 2026):** AI accompaniment (drums, bass, keys)\n- **Phase 5 (Q4 2026):** Voice commands, custom training datasets\n\n---\n\n## 🗺️ Roadmap\n\n### MVP Timeline\n\n| Sprint | Dates | Theme | Deliverables |\n|--------|-------|-------|--------------|\n| **1-2** | ✅ Complete | Backend + Audio | Analysis pipeline, audio playback, stems |\n| **3** | Oct 8-21 | Performance + A11y | 60fps, keyboard nav, ARIA, high contrast |\n| **4** | Oct 22-Nov 4 | Enhanced Editing | Chord autocomplete, drag sections, emergency font |\n| **5** | Nov 5-18 | Polish + Testing | Animations, loading states, user testing |\n| **MVP** | Nov 22 | Launch | Feature complete, accessible, bug-free |\n\n### Sprint 3 Breakdown (Oct 8-21)\n\n**Week 1: Performance**\n1. Optimize TeleprompterView rendering (virtual scrolling)\n2. Add syllable pulse animation\n3. Implement auto-centering (50% viewport)\n\n**Week 2: Accessibility**\n1. Keyboard navigation (8 shortcuts)\n2. ARIA labels on all elements\n3. High contrast mode\n4. Focus indicators\n\n**Acceptance Criteria:**\n- [ ] 60fps sustained for 10-min song\n- [ ] All elements keyboard accessible\n- [ ] WCAG AAA contrast ratios\n- [ ] Lighthouse accessibility score: 95+\n\n---\n\n## 🔧 Developer Guide\n\n### Project Structure\n\n```\nPerformia/\n├── frontend/                  # React frontend\n│   ├── components/           # React components\n│   ├── services/             # Library service, etc.\n│   ├── hooks/                # Custom hooks\n│   ├── data/                 # Mock data\n│   ├── types.ts              # TypeScript definitions\n│   └── index.css             # Global styles\n│\n├── backend/                   # Python backend\n│   ├── src/\n│   │   ├── main.py           # FastAPI server\n│   │   ├── services/         # Audio analysis\n│   │   └── schemas/          # JSON schemas\n│   └── requirements.txt\n│\n└── PERFORMIA_MASTER_DOCS.md  # This file\n```\n\n### Development Workflow\n\n1. **Start Backend:**\n   ```bash\n   cd backend\n   python src/main.py\n   ```\n\n2. **Start Frontend:**\n   ```bash\n   cd frontend\n   npm run dev\n   ```\n\n3. **Make Changes:**\n   - Hot reload enabled (Vite)\n   - Backend restarts on file change\n\n4. **Test:**\n   ```bash\n   # Frontend\n   npm test\n\n   # Backend\n   pytest\n   ```\n\n5. **Commit:**\n   ```bash\n   git add .\n   git commit -m \"feat: description\"\n   git push\n   ```\n\n### Key Files to Know\n\n| File | Purpose |\n|------|---------|\n| `frontend/App.tsx` | Main app component, state management |\n| `frontend/components/TeleprompterView.tsx` | Living Chart display |\n| `frontend/components/AudioPlayer.tsx` | Audio playback controls |\n| `frontend/types.ts` | TypeScript type definitions |\n| `backend/src/main.py` | FastAPI server, routes |\n| `backend/schemas/song_map.schema.json` | Song Map structure |\n\n### Adding a New Component\n\n1. Create file in `frontend/components/`\n2. Define TypeScript interface for props\n3. Implement component with accessibility (ARIA labels)\n4. Add to parent component\n5. Update this documentation\n\n### Debugging Tips\n\n**Frontend:**\n- React DevTools for component tree\n- Console.log sparingly (use breakpoints)\n- Check Network tab for API calls\n\n**Backend:**\n- FastAPI auto-docs: `http://localhost:8000/docs`\n- Check logs for errors\n- Use Python debugger (pdb)\n\n**Performance:**\n- Chrome DevTools Performance tab\n- Target: 60fps (16.67ms per frame)\n- Check for layout thrashing\n\n---\n\n## ♿ Accessibility\n\n### WCAG Compliance\n\n**Target:** WCAG 2.1 AA minimum, AAA for critical elements\n\n### Contrast Ratios\n\n| Element | Ratio | Standard |\n|---------|-------|----------|\n| Lyrics | 16:1 | AAA |\n| Chords | 7:1 | AAA |\n| UI Controls | 4.5:1 | AA |\n\n### Keyboard Navigation\n\n| Key | Action | Context |\n|-----|--------|---------|\n| **Space** | Play/pause | Teleprompter |\n| **←/→** | Prev/next section | Teleprompter |\n| **Cmd+,** | Open settings | Global |\n| **Cmd+L** | Open library | Global |\n| **Cmd+E** | Toggle edit mode | Global |\n| **Esc** | Close modal | Global |\n| **Tab** | Navigate controls | Settings |\n| **Cmd+↑/↓** | Font size ±10% | Teleprompter |\n\n### Screen Reader Support\n\n- Semantic HTML (`<header>`, `<main>`, `<nav>`)\n- ARIA labels on all interactive elements\n- ARIA live regions for dynamic content\n- Announce section changes and playback state\n\n### Visual Accessibility\n\n- **High contrast mode** (black-on-white toggle)\n- **Focus indicators** (2px cyan outline)\n- **Reduced motion** (disable animations)\n- **Minimum touch targets** (44x44px)\n\n### Testing Checklist\n\n- [ ] Tab through all interactive elements\n- [ ] Test with screen reader (VoiceOver/NVDA)\n- [ ] Check contrast with WCAG Color Contrast Checker\n- [ ] Test reduced motion preference\n- [ ] Verify focus indicators visible\n\n---\n\n## 📊 Success Metrics\n\n### Quantitative Targets\n\n| Metric | Target | Current | Status |\n|--------|--------|---------|--------|\n| **Time to first performance** | <30s | ✅ 25s | ✅ Met |\n| **Song search speed** | <5s | ✅ 3s | ✅ Met |\n| **Settings adjust speed** | <2s | 🔨 4s | 🔨 In progress |\n| **Frame rate** | 60fps | 🔨 50fps | 🔨 In progress |\n| **Audio latency** | <50ms | ✅ 35ms | ✅ Met |\n| **Analysis speed** | <30s/song | ✅ 22s | ✅ Met |\n| **Chord accuracy** | 90%+ | ✅ 92% | ✅ Met |\n| **Lyric accuracy** | 95%+ | ✅ 96% | ✅ Met |\n\n### Qualitative Targets\n\n- **Ease of use:** 4.5+ stars (out of 5)\n- **Feature discovery:** 80%+ without tutorial\n- **Visual clarity:** 95%+ \"easy to read\"\n- **Performance satisfaction:** 90%+ \"feels instant\"\n\n### Analytics to Track\n\n1. Time to first performance\n2. Songs uploaded per user\n3. Most used features\n4. Error rate\n5. Session duration\n6. Return rate (weekly active)\n\n---\n\n## 🔍 Frequently Asked Questions\n\n### General\n\n**Q: What audio formats are supported?**\nA: WAV, MP3, M4A, FLAC\n\n**Q: How long does song analysis take?**\nA: ~30 seconds per song (varies by length)\n\n**Q: Can I edit the auto-generated chords?**\nA: Yes, use Full Chart to edit chords inline\n\n**Q: Does it work offline?**\nA: Not yet (planned for Phase 3)\n\n### Technical\n\n**Q: Why 60fps target?**\nA: Smooth scrolling is critical for reading during performance. 60fps = 16.67ms per frame.\n\n**Q: Canvas vs DOM for rendering?**\nA: Currently DOM. Will optimize first, consider Canvas only if needed (accessibility trade-off).\n\n**Q: How does syllable sync work?**\nA: RequestAnimationFrame checks current audio time, finds matching syllable, updates highlight.\n\n**Q: Why Performia cyan?**\nA: High contrast with warm amber chords, signals \"now\", cool color stands out.\n\n---\n\n## 📝 Contribution Guidelines\n\n### Code Style\n\n- **TypeScript:** Strict mode, explicit types\n- **React:** Functional components, hooks\n- **CSS:** Tailwind utility classes, avoid inline styles\n- **Naming:** camelCase for variables, PascalCase for components\n\n### Commit Messages\n\n```\nfeat: Add emergency font adjust gesture\nfix: Resolve audio sync latency issue\ndocs: Update component API reference\nrefactor: Optimize TeleprompterView rendering\ntest: Add unit tests for chord validation\n```\n\n### Pull Requests\n\n1. Create feature branch: `git checkout -b feat/my-feature`\n2. Make changes and commit\n3. Push: `git push -u origin feat/my-feature`\n4. Open PR with description\n5. Request review\n6. Merge after approval\n\n---\n\n## 🐛 Known Issues & Limitations\n\n### Current Limitations\n\n1. **Desktop only** (mobile support in Phase 2)\n2. **Local storage** (no cloud sync yet)\n3. **No collaboration** (single user editing)\n4. **English lyrics only** (multi-language in future)\n\n### Known Bugs\n\n*None currently tracked for MVP*\n\n### Workarounds\n\n**Issue:** Font size changes lag\n**Workaround:** Use preset sizes instead of slider\n\n**Issue:** Large songs (>10min) slow down\n**Workaround:** Virtual scrolling coming in Sprint 3\n\n---\n\n## 📚 Additional Resources\n\n### External Links\n\n- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)\n- [React Performance](https://react.dev/learn/render-and-commit)\n- [Tailwind CSS Docs](https://tailwindcss.com/docs)\n- [FastAPI Docs](https://fastapi.tiangolo.com/)\n- **[SongPrep Repository](https://github.com/tencent-ailab/SongPrep)** - Song structure parsing\n- **[SongPrep Paper](https://arxiv.org/abs/2509.17404)** - Technical details\n\n### Internal Files\n\n- `backend/schemas/song_map.schema.json` - Song Map structure\n- `frontend/types.ts` - TypeScript definitions\n- `.claude/CLAUDE.md` - Agent SDK instructions\n- **`docs/research/SONGPREP_ANALYSIS.md`** - SongPrep integration research\n\n---\n\n## 📅 Document History\n\n| Version | Date | Changes |\n|---------|------|---------|\n| 3.0 | Oct 1, 2025 | Consolidated all docs into master file |\n| 2.0 | Oct 1, 2025 | Added AudioPlayer & StemSelector specs |\n| 1.0 | Sep 30, 2025 | Initial documentation structure |\n\n---\n\n## 🎯 Core Principle\n\n> **\"The best interface for performance is no interface at all.\"**\n\nEvery decision must answer:\n**\"Does this help the musician perform better, or does it distract?\"**\n\nIf it distracts → Cut it.\nIf it helps → Polish it until it's invisible.\n\n---\n\n**Maintained by:** Performia Development Team\n**Next Review:** End of Sprint 3 (Oct 21, 2025)\n**Questions?** Check the FAQ or open an issue\n"
+}


### PR DESCRIPTION
## Summary
Removes problematic fallback metadata fields that could cause database compatibility issues.

## Changes
- Remove `_fallback: true` boolean field
- Remove `_originalPRDPreview` string field
- Throw descriptive error when both parse and retry fail
- Prevents silent failures

## Why
When retry logic fails, we should show the user a clear error message rather than returning a fallback spec with metadata fields that might cause downstream issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>