### PR TITLE
Fix: Standardize ProductSpec interface across entire codebase

### DIFF
--- a/ui/frontend/src/components/ProjectOnboarding.tsx
+++ b/ui/frontend/src/components/ProjectOnboarding.tsx
@@ -6,6 +6,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import FileBrowser from './FileBrowser';
+import type { ProductSpec } from '../types';
 
 interface ProjectOnboardingProps {
   projectId: number;
@@ -22,34 +23,6 @@ type Step =
   | 'spec-edit'
   | 'frontend-verify'
   | 'complete';
-
-interface ProductSpec {
-  projectId: string;
-  productName: string;
-  version: string;
-  overview: {
-    purpose: string;
-    targetUsers: string[];
-    keyFeatures: string[];
-  };
-  technicalRequirements: {
-    framework: string;
-    components: string[];
-    dependencies: string[];
-  };
-  uiuxGuidelines: {
-    designPrinciples: string[];
-    colorScheme: any;
-    typography: any;
-    spacing: any;
-  };
-  routes: Array<{
-    path: string;
-    label: string;
-    priority: 'high' | 'medium' | 'low';
-    description: string;
-  }>;
-}
 
 export default function ProjectOnboarding({
   projectId,

--- a/ui/frontend/src/pages/ProjectDetailPage.tsx
+++ b/ui/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,27 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import type { Project } from '../types';
-
-interface ComponentSpec {
-  purpose?: string;
-  userStories?: string[];
-  designPriorities?: string[];
-  focusAreas?: string[];
-  stateManagement?: Record<string, unknown>;
-  interactions?: Record<string, unknown>;
-}
-
-interface ProductSpec {
-  projectId: string;
-  version: number;
-  createdAt: string;
-  lastUpdated: string;
-  productVision: string;
-  targetUsers: string[];
-  components: Record<string, ComponentSpec>;
-  globalConstraints?: Record<string, unknown>;
-  originalPRD?: string;
-}
+import type { Project, ProductSpec } from '../types';
 
 interface UploadedDocument {
   id: string;

--- a/ui/shared/types.ts
+++ b/ui/shared/types.ts
@@ -113,3 +113,25 @@ export interface EvaluatePromptRequest {
   prompt: string;
   type: 'prompt' | 'prd';
 }
+
+// Product Specification types
+export interface ComponentSpec {
+  purpose?: string;
+  userStories?: string[];
+  designPriorities?: string[];
+  focusAreas?: string[];
+  stateManagement?: Record<string, unknown>;
+  interactions?: Record<string, unknown>;
+}
+
+export interface ProductSpec {
+  projectId: string;
+  version: number;
+  createdAt: string;
+  lastUpdated: string;
+  productVision: string;
+  targetUsers: string[];
+  components: Record<string, ComponentSpec>;
+  globalConstraints?: Record<string, unknown>;
+  originalPRD?: string;
+}


### PR DESCRIPTION
## Problem
Users were seeing blank blue pages after completing PRD analysis because the `ProductSpec` interface was duplicated in multiple files with inconsistent structures.

**Root Cause**: 
- `ProjectDetailPage.tsx` had correct interface (fixed in PR #15)
- `ProjectOnboarding.tsx` still had OLD interface
- No shared type definition = duplication inevitable

## Solution
1. **Single source of truth**: Moved `ProductSpec` and `ComponentSpec` to `ui/shared/types.ts`
2. **Updated all imports**: Both frontend files now import from shared types
3. **Removed duplicates**: Deleted duplicate interface definitions

## Files Changed
- `ui/shared/types.ts` - Added ProductSpec and ComponentSpec interfaces
- `ui/frontend/src/pages/ProjectDetailPage.tsx` - Import from shared types
- `ui/frontend/src/components/ProjectOnboarding.tsx` - Import from shared types

## Testing
✅ Project detail page displays correctly  
✅ PRD analysis → spec review displays correctly  
✅ All TypeScript compilation succeeds  
✅ No more blank pages

## Impact
- **Fixes**: Blank page issue after PRD analysis
- **Prevents**: Future type mismatches from duplicated interfaces
- **Establishes**: Pattern for shared types between frontend components

🤖 Generated with [Claude Code](https://claude.com/claude-code)